### PR TITLE
The reference to the Swift Package on app target was removed

### DIFF
--- a/Example/NFCPassportReaderApp.xcodeproj/project.pbxproj
+++ b/Example/NFCPassportReaderApp.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		A133D55F22B3D5A000E928EB /* NFCPassportReader */ = {isa = PBXFileReference; lastKnownFileType = folder; name = NFCPassportReader; path = ..; sourceTree = "<group>"; };
 		A16EB22D22A9E9E10008F53F /* NFCPassportReaderApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NFCPassportReaderApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A16EB23022A9E9E10008F53F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A16EB23222A9E9E10008F53F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -44,7 +43,6 @@
 		A16EB22422A9E9E10008F53F = {
 			isa = PBXGroup;
 			children = (
-				A133D55F22B3D5A000E928EB /* NFCPassportReader */,
 				A16EB22F22A9E9E10008F53F /* NFCPassportReaderApp */,
 				A16EB22E22A9E9E10008F53F /* Products */,
 				A16FC0C222B0F22C00144B5B /* Frameworks */,


### PR DESCRIPTION
The reference of the swift package in the app target causes dependency
mismatch with the actual integrated swift package. Removing reference
from the app target would allow the package to be resolved properly.