### PR TITLE
Fix AA and encoding of Le in DO97

### DIFF
--- a/Sources/NFCPassportReader/SecureMessaging.swift
+++ b/Sources/NFCPassportReader/SecureMessaging.swift
@@ -41,7 +41,7 @@ public class SecureMessaging {
         }
         if apdu.expectedResponseLength > 0 {
             tmp += " and DO97"
-            do97 = self.buildD097(apdu: apdu)
+            do97 = try self.buildD097(apdu: apdu)
         }
         
         let M = cmdHeader + do87 + do97
@@ -225,11 +225,16 @@ public class SecureMessaging {
         return res
     }
 
-    func buildD097(apdu : NFCISO7816APDU) -> [UInt8] {
-        let res : [UInt8] = [0x97, 0x01] + intToBin(apdu.expectedResponseLength)
+    func buildD097(apdu : NFCISO7816APDU) throws -> [UInt8] {
+        let le = apdu.expectedResponseLength
+        var binLe = intToBin(le)
+        if (le == 256 || le == 65536) {
+            binLe = [0x00] + (le > 256 ? [0x00] : [])
+        }
+        
+        let res : [UInt8] = try [0x97] + toAsn1Length(binLe.count) + binLe
         Log.debug("Build DO'97")
         Log.debug("\tDO97: \(res)")
         return res
     }
-    
 }

--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -209,7 +209,7 @@ public class TagReader {
     func doInternalAuthentication( challenge: [UInt8], completed: @escaping (ResponseAPDU?, TagError?)->() ) {
         let randNonce = Data(challenge)
         
-        let cmd : NFCISO7816APDU = NFCISO7816APDU(instructionClass: 00, instructionCode: 0x88, p1Parameter: 0, p2Parameter: 0, data: randNonce, expectedResponseLength: 50)
+        let cmd = NFCISO7816APDU(instructionClass: 00, instructionCode: 0x88, p1Parameter: 0, p2Parameter: 0, data: randNonce, expectedResponseLength: 256)
 
         send( cmd: cmd, completed: completed )
     }


### PR DESCRIPTION
This PR fixes encoding of Le field in DO97. It also fixes active authentication by setting Le value in DO97 to `0x00` - variable long signature. 

**Background:**

*DO97*
The `Le` field in DO97 (which tells IC the number of data bytes the IS expects in response)  should be encoded as TLV: [ `0x97` - tag, encoded `Le` size, encoded `Le` bytes ]
The `NFCISO7816APDU` class expects for `Le` value from 1 - 65536 and -1. If you want to set `Le` to be variable data length (`0x00`), the `Le` field should be set to `256`  (or `65536` - extended Le). The library wrongly encoded `Le` in DO97 for 256 (and 65536) as `0x100` (`0x10000`) insted of `0x00` (`0x0000`). This PR fixes this.

*Internal authentication (AA)* 
The DO97 should be always present in the AA procedure. The `Le` field in DO97 should be set to either variable signature length or to an actual length of the returned signature. The implementation used fixed length (50) for `Le` which limited library to 50 bytes long signatures. PR fixes this by setting `Le` to 256 (`0x00`) - variable long signature.