### PR TITLE
Add SHA384 support

### DIFF
--- a/Sources/NFCPassportReader/DataGroupParser.swift
+++ b/Sources/NFCPassportReader/DataGroupParser.swift
@@ -96,6 +96,8 @@ public class DataGroup {
             ret = calcSHA256Hash(self.data)
         } else if hashAlgorythm == "SHA1" {
             ret = calcSHA1Hash(self.data)
+        } else if hashAlgorythm == "SHA384" {
+            ret = calcSHA384Hash(self.data)
         }
         
         return ret

--- a/Sources/NFCPassportReader/NFCPassportModel.swift
+++ b/Sources/NFCPassportReader/NFCPassportModel.swift
@@ -130,6 +130,8 @@ public class NFCPassportModel {
                 ret[key] = calcSHA256Hash(value.body)
             } else if hashAlgorythm == "SHA1" {
                 ret[key] = calcSHA1Hash(value.body)
+            } else if hashAlgorythm == "SHA384" {
+                ret[key] = calcSHA384Hash(value.body)
             }
         }
         
@@ -269,7 +271,7 @@ public class NFCPassportModel {
     
     /// Parses an text ASN1 structure, and extracts the Hash Algorythm and Hashes contained from the Octect strings
     /// - Parameter content: the text ASN1 stucure format
-    /// - Returns: The Has Algorythm used - either SHA1 or SHA256, and a dictionary of hashes for the datagroups (currently only DG1 and DG2 are handled)
+    /// - Returns: The Has Algorythm used - SHA1, SHA256 or SHA384, and a dictionary of hashes for the datagroups (currently only DG1 and DG2 are handled)
     private func parseSODSignatureContent( _ content : String ) throws -> (String, [DataGroupId : String]){
         var currentDG = ""
         var sodHashAlgo = ""
@@ -285,6 +287,8 @@ public class NFCPassportModel {
                     sodHashAlgo = "SHA1"
                 } else if line.contains( "sha256" ) {
                     sodHashAlgo = "SHA256"
+                } else if line.contains( "sha384" ) {
+                    sodHashAlgo = "SHA384"
                 }
             } else if line.contains("d=3" ) && line.contains( "INTEGER" ) {
                 if let range = line.range(of: "INTEGER") {

--- a/Sources/NFCPassportReader/Utils.swift
+++ b/Sources/NFCPassportReader/Utils.swift
@@ -282,4 +282,19 @@ func calcSHA256Hash( _ data: [UInt8] ) -> [UInt8] {
     #endif
 }
 
-
+/// This function is used during the Derivation of Document Basic Acces Keys.
+/// @param Kseed: A 16 bytes random value
+/// @type Kseed: Binary
+/// @return: A set of two 8 bytes encryption keys
+@available(iOS 13, *)
+func calcSHA384Hash( _ data: [UInt8] ) -> [UInt8] {
+    #if canImport(CryptoKit)
+    var sha384 = SHA384()
+    sha384.update(data: data)
+    let hash = sha384.finalize()
+    
+    return Array(hash)
+    #else
+    fatalError("Couldn't import CryptoKit")
+    #endif
+}


### PR DESCRIPTION
New German passports (e.g. issued in November 2019) uses `SHA384` to hash SOD (`"    8:d=2  hl=2 l=   9 prim:   OBJECT            :sha384"`). 
As the current implementation doesn't support hash calculation with `SHA384`, the library throws the error `PassiveAuthenticationError.UnableToParseSODHashes("Unable to find hash algorythm used" )` when tries to ensure the read data had not been tampered with.
This PR adds support to calculate hash with `SHA384` the same way as implemented with with `SHA1` and `SHA256`.