### PR TITLE
WP: Add basic support for Objective-C

### DIFF
--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "NFCPassportReader"
-  spec.version      = "1.0.12"
+  spec.version      = "1.0.13"
   spec.summary      = "This package handles reading an NFC Enabled passport using iOS 13 CoreNFC APIS"
 
   spec.homepage     = "https://github.com/AndyQ/NFCPassportReader"
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.platform = :ios
   spec.ios.deployment_target = "12.0"
 
-  spec.source       = { :git => "https://github.com/AndyQ/NFCPassportReader.git", :tag => "#{spec.version}" }
+  spec.source       = { :git => "https://github.com/alv-ti8m/NFCPassportReader.git", :tag => "#{spec.version}" }
 
   spec.source_files  = "Sources/**/*.{swift}"
 

--- a/Sources/NFCPassportReader/NFCPassportModel.swift
+++ b/Sources/NFCPassportReader/NFCPassportModel.swift
@@ -16,7 +16,7 @@ public struct DataGroupHash {
 }
 
 @available(iOS 13, *)
-public class NFCPassportModel {
+public class NFCPassportModel: NSObject {
     
     public private(set) lazy var documentType : String = { return String( passportDataElements?["5F03"]?.first ?? "?" ) }()
     public private(set) lazy var documentSubType : String = { return String( passportDataElements?["5F03"]?.last ?? "?" ) }()
@@ -103,11 +103,6 @@ public class NFCPassportModel {
         guard let dg1 = dataGroupsRead[.DG1] as? DataGroup1 else { return nil }
         
         return dg1.elements
-    }
-        
-    
-    public init() {
-        
     }
     
     public func addDataGroup(_ id : DataGroupId, dataGroup: DataGroup ) {

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -79,14 +79,46 @@ public class PassportReader : NSObject {
     private var masterListURL : URL?
     private var shouldNotReportNextReaderSessionInvalidationErrorUserCanceled : Bool = false
 
+    @objc
     public init( masterListURL: URL? = nil ) {
         super.init()
         
         self.masterListURL = masterListURL
     }
     
+    @objc
     public func setMasterListURL( _ masterListURL : URL ) {
         self.masterListURL = masterListURL
+    }
+    
+    @objc
+    public func readPassport(
+        mrzKey: String,
+        completed: @escaping (NFCPassportModel?, Error?) -> ()
+    ) {
+        self.readPassport(
+            mrzKey: mrzKey,
+            tags: [],
+            skipSecureElements: true,
+            customDisplayMessage: nil,
+            completed: completed
+        )
+    }
+    
+    @objc
+    public func readPassport(
+        mrzKey: String,
+        tags: [Int] = [],
+        skipSecureElements: Bool = true,
+        completed: @escaping (NFCPassportModel?, Error?) -> ()
+    ) {
+        self.readPassport(
+            mrzKey: mrzKey,
+            tags: tags.compactMap({ DataGroupId(rawValue: $0) }),
+            skipSecureElements: skipSecureElements,
+            customDisplayMessage: nil,
+            completed: completed
+        )
     }
     
     public func readPassport( mrzKey : String, tags: [DataGroupId] = [], skipSecureElements :Bool = true, customDisplayMessage: ((NFCViewDisplayMessage) -> String?)? = nil, completed: @escaping (NFCPassportModel?, TagError?)->()) {

--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -76,6 +76,7 @@ public enum TagError: Error {
 }
 
 @available(iOS 13, *)
+@objc
 public enum DataGroupId : Int, CaseIterable {
     case COM = 0x60
     case DG1 = 0x61


### PR DESCRIPTION
Implement basic support for Objective-C.
Now NFCPassportReader can also be used on Objective-C projects.
If only supports readPassport method without custom messages for now.