### PR TITLE
CAN support for PACE

### DIFF
--- a/Example/NFCPassportReaderApp.xcodeproj/project.pbxproj
+++ b/Example/NFCPassportReaderApp.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		A1FDC53225D3F19E00D22FF4 /* ViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FDC53125D3F19E00D22FF4 /* ViewModifiers.swift */; };
 		A1FDC53425D3F1DE00D22FF4 /* CheckBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FDC53325D3F1DE00D22FF4 /* CheckBoxView.swift */; };
 		A1FDC53625D43AB400D22FF4 /* MRZEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FDC53525D43AB400D22FF4 /* MRZEntryView.swift */; };
+		F6BB3B65264092C8008E30E7 /* CANEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BB3B64264092C8008E30E7 /* CANEntryView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +88,7 @@
 		A7BD003B33886ED0F3F03325 /* Pods_NFCPassportReaderApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NFCPassportReaderApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B239DD4BD3AA9ECF4F595D22 /* Pods-NFCPassportReaderApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NFCPassportReaderApp.release.xcconfig"; path = "Target Support Files/Pods-NFCPassportReaderApp/Pods-NFCPassportReaderApp.release.xcconfig"; sourceTree = "<group>"; };
 		DA39DA603B1A7EBD8FC38112 /* Pods_NFCPassportReaderAppTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NFCPassportReaderAppTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F6BB3B64264092C8008E30E7 /* CANEntryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CANEntryView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -194,6 +196,7 @@
 				A1298C9B25D539CD00F5713E /* HelperViews */,
 				A17134BD22C8EF7100C457C3 /* MainView.swift */,
 				A1FDC53525D43AB400D22FF4 /* MRZEntryView.swift */,
+				F6BB3B64264092C8008E30E7 /* CANEntryView.swift */,
 				A1FDC52D25D3F15D00D22FF4 /* SettingsView.swift */,
 				A1816E9B22C9059F00F546A0 /* PassportView.swift */,
 				A1C234C125DD19DE003FFD79 /* PassportSummaryView.swift */,
@@ -404,6 +407,7 @@
 				A1816E9C22C9059F00F546A0 /* PassportView.swift in Sources */,
 				A1769DF725D3E318006002D1 /* SettingsStore.swift in Sources */,
 				A1298C9F25D53A5C00F5713E /* ViewExt.swift in Sources */,
+				F6BB3B65264092C8008E30E7 /* CANEntryView.swift in Sources */,
 				A182DE6325DD730D00341204 /* FileManagerExt.swift in Sources */,
 				A1FDC52E25D3F15D00D22FF4 /* SettingsView.swift in Sources */,
 				A182DE6125DD6F1300341204 /* StoredPassportView.swift in Sources */,

--- a/Example/NFCPassportReaderApp/Model/SettingsStore.swift
+++ b/Example/NFCPassportReaderApp/Model/SettingsStore.swift
@@ -20,8 +20,9 @@ final class SettingsStore: ObservableObject {
         static let passportNumber = "passportNumber"
         static let dateOfBirth = "dateOfBirth"
         static let dateOfExpiry = "dateOfExpiry"
+        static let cardAccessNumber = "can"
         
-        static let allVals = [captureLog, logLevel, useNewVerification, passportNumber, dateOfBirth, dateOfExpiry]
+        static let allVals = [captureLog, logLevel, useNewVerification, passportNumber, dateOfBirth, dateOfExpiry, cardAccessNumber]
     }
     
     private let cancellable: Cancellable
@@ -41,6 +42,7 @@ final class SettingsStore: ObservableObject {
             Keys.passportNumber: "",
             Keys.dateOfBirth: Date().timeIntervalSince1970,
             Keys.dateOfExpiry: Date().timeIntervalSince1970,
+            Keys.cardAccessNumber: "",
         ])
         
         cancellable = NotificationCenter.default
@@ -101,6 +103,11 @@ final class SettingsStore: ObservableObject {
             let d = Date(timeIntervalSince1970: defaults.double(forKey: Keys.dateOfExpiry))
             return d
         }
+    }
+
+    var cardAccessNumber: String {
+        set { defaults.set(newValue, forKey: Keys.cardAccessNumber) }
+        get { defaults.string(forKey: Keys.cardAccessNumber) ?? "" }
     }
     
     @Published var passport : NFCPassportModel?

--- a/Example/NFCPassportReaderApp/Views/CANEntryView.swift
+++ b/Example/NFCPassportReaderApp/Views/CANEntryView.swift
@@ -1,0 +1,59 @@
+//
+//  CANEntryView.swift
+//  NFCPassportReaderApp
+//
+//  Created by Tim Wilbrink on 23.04.21.
+//
+
+import SwiftUI
+
+struct CANEntryView : View {
+    @EnvironmentObject var settings: SettingsStore
+
+    // These will be removed once DatePicker inline works correctly
+    @State private var editDOB = false
+    @State private var editDOE = false
+    @State private var editDateTitle : String = ""
+
+    var body : some View {
+        let canBinding = Binding<String>(get: {
+            settings.cardAccessNumber
+        }, set: {
+            settings.cardAccessNumber = $0.uppercased()
+        })
+        VStack {
+
+            TextField("CAN", text: canBinding)
+                .textCase(.uppercase)
+                .modifier(ClearButton(text: canBinding))
+                .textContentType(.name)
+                .foregroundColor(Color.primary)
+                .padding([.leading, .trailing])
+                .ignoresSafeArea(.keyboard, edges: .all)
+
+            Divider()
+
+
+        }
+        .ignoresSafeArea(.keyboard, edges: .bottom)
+    }
+}
+
+
+#if DEBUG
+struct CANEntryView_Previews : PreviewProvider {
+
+    static var previews: some View {
+        let settings = SettingsStore()
+
+        return
+            Group {
+                NavigationView {
+                    CANEntryView()
+                }
+                .environmentObject(settings)
+                .environment( \.colorScheme, .light)
+        }
+    }
+}
+#endif

--- a/Example/NFCPassportReaderApp/Views/MainView.swift
+++ b/Example/NFCPassportReaderApp/Views/MainView.swift
@@ -52,6 +52,8 @@ struct MainView : View {
                         }.padding([.top, .trailing])
                     }
                     MRZEntryView()
+                    Divider()
+                    CANEntryView()
                     
                     Button(action: {
                         self.scanPassport()
@@ -132,6 +134,8 @@ extension MainView {
         let dob = df.string(from:settings.dateOfBirth)
         let doe = df.string(from:settings.dateOfExpiry)
 
+        let can = settings.cardAccessNumber
+
         let passportUtils = PassportUtils()
         let mrzKey = passportUtils.getMRZKey( passportNumber: pptNr, dateOfBirth: dob, dateOfExpiry: doe)
 
@@ -149,9 +153,16 @@ extension MainView {
         Log.logLevel = settings.logLevel
         Log.storeLogs = settings.shouldCaptureLogs
         Log.clearStoredLogs()
-        
+
+        var accessKey = mrzKey
+        var paceKeyReference : UInt8 = PACEHandler.MRZ_PACE_KEY_REFERENCE
+        if (can != "") {
+            accessKey = can
+            paceKeyReference = PACEHandler.CAN_PACE_KEY_REFERENCE
+        }
+
         // This is also how you can override the default messages displayed by the NFC View Controller
-        passportReader.readPassport(mrzKey: mrzKey, customDisplayMessage: { (displayMessage) in
+        passportReader.readPassport(accessKey: accessKey, paceKeyReference: paceKeyReference, customDisplayMessage: { (displayMessage) in
             switch displayMessage {
                 case .requestPresentPassport:
                     return "Hold your iPhone near an NFC enabled passport."


### PR DESCRIPTION
You can use the Card Access Number together with PACE.
In the Example App the CAN will be used if entered and is preferred over the MRZ data.