### PR TITLE
Fix for CA when keyId is not nil

### DIFF
--- a/Sources/NFCPassportReader/DataGroups/SecurityInfo.swift
+++ b/Sources/NFCPassportReader/DataGroups/SecurityInfo.swift
@@ -91,7 +91,7 @@ public class SecurityInfo {
                 if optionalData == nil {
                     return ChipAuthenticationPublicKeyInfo(oid:oid, pubKey:subjectPublicKeyInfo);
                 } else {
-                    let keyId = Int(optionalData!.value)
+                    let keyId = Int(optionalData!.value, radix: 16)
                     return ChipAuthenticationPublicKeyInfo(oid:oid, pubKey:subjectPublicKeyInfo, keyId: keyId);
                 }
                 
@@ -99,7 +99,7 @@ public class SecurityInfo {
         } else if ChipAuthenticationInfo.checkRequiredIdentifier(oid) {
             let version = Int(requiredData.value) ?? -1
             if let optionalData = optionalData {
-                let keyId = Int(optionalData.value)
+                let keyId = Int(optionalData.value, radix: 16)
                 return ChipAuthenticationInfo(oid: oid, version: version, keyId: keyId);
             } else {
                 return ChipAuthenticationInfo(oid: oid, version: version);


### PR DESCRIPTION
Chip Authentication fails for some documents where keyId is explicitly set. keyId is optional, and is only meant for documents that support multiple chip authentication algorithms / keys. Most documents I have tested have not set keyId for ChipAuthenticationInfo / ChipAuthenticationPublicKeyInfo (optionalData is nil). 


However some specimen documents, including documents from Malta, explicitly sets keyId, even though it only supports one Chip Authentication Info / key pair. Chip Authentication fails with error 0x6A 0x80 - Incorrect parameters in the data field for this document.
 

In the current implementation we read keyId as an integer. If we instead read keyId with radix 16, chip authentication succeeds. Have tested this on

- Documents with only one ChipAuthenticationInfo / ChipAuthenticationPublicKeyInfo pair where optional data is nil
- Documents with only one ChipAuthenticationInfo / ChipAuthenticationPublicKeyInfo pair where optional data is explicitly set
- Documents with ChipAuthenticationPublicKeyInfo but without ChipAuthenticationInfo
- Documents with multiple ChipAuthenticationInfo / ChipAuthenticationPublicKeyInfo pairs