### PR TITLE
Realiable personalNumber fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+/.DS_Store
+/Package.resolved
+/Sources/.DS_Store

--- a/Sources/NFCPassportReader/NFCPassportModel.swift
+++ b/Sources/NFCPassportReader/NFCPassportModel.swift
@@ -24,7 +24,6 @@ public class NFCPassportModel {
     
     public private(set) lazy var documentType : String = { return String( passportDataElements?["5F03"]?.first ?? "?" ) }()
     public private(set) lazy var documentSubType : String = { return String( passportDataElements?["5F03"]?.last ?? "?" ) }()
-    public private(set) lazy var personalNumber : String = { return (passportDataElements?["53"] ?? "?").replacingOccurrences(of: "<", with: "" ) }()
     public private(set) lazy var documentNumber : String = { return (passportDataElements?["5A"] ?? "?").replacingOccurrences(of: "<", with: "" ) }()
     public private(set) lazy var issuingAuthority : String = { return passportDataElements?["5F28"] ?? "?" }()
     public private(set) lazy var documentExpiryDate : String = { return passportDataElements?["59"] ?? "?" }()
@@ -68,6 +67,14 @@ public class NFCPassportModel {
         guard let dg11 = dataGroupsRead[.DG11] as? DataGroup11,
               let telephone = dg11.telephone else { return nil }
         return telephone
+    }()
+    
+    /// personal number
+    public private(set) lazy var personalNumber : String? = {
+        if let dg11 = dataGroupsRead[.DG11] as? DataGroup11,
+           let personalNumber = dg11.personalNumber { return personalNumber }
+        
+        return (passportDataElements?["53"] ?? "?").replacingOccurrences(of: "<", with: "" )
     }()
 
     public private(set) lazy var documentSigningCertificate : X509Wrapper? = {


### PR DESCRIPTION
Currently personalNumber is fetched from DG1, which contains MRZ information.

According to the ICAO implementation the actual personalNumber resides in DG11 (see https://www.icao.int/publications/documents/9303_p10_cons_en.pdf)

It appears that some passports does not contain DG11, so i left the original fetch from DG1 there for reliability.

**Note:**
DG1 personalNumber does not appear the same as in the actual passports, even though the implementation is correct. Eg. my personalNumber contains 9 digits, while DG1 returns 14 digits. DG11 on the other hand provides it correctly.