### PR TITLE
Invalidate session when cancel is tapped

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .upToNextMinor(from: "1.1.180"))
+        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .exact("1.1.180"))
 
     ],
     targets: [

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -114,6 +114,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
         // If necessary, you may handle the error. Note session is no longer valid.
         // You must create a new session to restart RF polling.
         Log.debug( "tagReaderSession:didInvalidateWithError - \(error.localizedDescription)" )
+        self.readerSession?.invalidate()
         self.readerSession = nil
 
         if let readerError = error as? NFCReaderError, readerError.code == NFCReaderError.readerSessionInvalidationErrorUserCanceled


### PR DESCRIPTION
Current behaviour only sets the session to nil. But the session that was cancelled continues to read, causing weird behaviour such that a new session is unable to start reading before the previous one has been properly invalidated.

This PR will solve that behaviour