### PR TITLE
Invalidate session when cancel is tapped

### DIFF
--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -114,6 +114,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
         // If necessary, you may handle the error. Note session is no longer valid.
         // You must create a new session to restart RF polling.
         Log.debug( "tagReaderSession:didInvalidateWithError - \(error.localizedDescription)" )
+        self.readerSession?.invalidate()
         self.readerSession = nil
 
         if let readerError = error as? NFCReaderError, readerError.code == NFCReaderError.readerSessionInvalidationErrorUserCanceled


### PR DESCRIPTION
Current behaviour only sets the session to nil. But the session that was cancelled continues to read, cause weird behaviour such as a new session is unable to start reading before the previous has been invalidated correctly