### PR TITLE
make DataGroup12 class public

### DIFF
--- a/Sources/NFCPassportReader/DataGroups/DataGroup12.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup12.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 @available(iOS 13, macOS 10.15, *)
-class DataGroup12 : DataGroup {
+public class DataGroup12 : DataGroup {
     
     public private(set) var issuingAuthority : String?
     public private(set) var dateOfIssue : String?


### PR DESCRIPTION
Hello, thanks for your great work,

The DataGroup12 seems to be internal and it cannot be accessed outside the library:

```swift
if let dg12 = pass.dataGroupsRead[.DG12] as? DataGroup12 {
  /* get dg12.dateOfIssue */
}
```

this PR makes it public, thanks