### PR TITLE
Improved compatibility with some documents by omitting LE

### DIFF
--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -112,7 +112,7 @@ public class TagReader {
         
         let data = oidBytes + keyTypeBytes
             
-        let cmd = NFCISO7816APDU(instructionClass: 00, instructionCode: 0x22, p1Parameter: 0xC1, p2Parameter: 0xA4, data: Data(data), expectedResponseLength: 256)
+        let cmd = NFCISO7816APDU(instructionClass: 00, instructionCode: 0x22, p1Parameter: 0xC1, p2Parameter: 0xA4, data: Data(data), expectedResponseLength: -1)
         
         return try await send( cmd: cmd )
     }
@@ -222,7 +222,7 @@ public class TagReader {
         // By executing above SELECT command (with data=0x3F00) master file should be selected and you should be able to read EF.CardAccess from passport.
         
         // First select master file
-        let cmd : NFCISO7816APDU = NFCISO7816APDU(instructionClass: 0x00, instructionCode: 0xA4, p1Parameter: 0x00, p2Parameter: 0x0C, data: Data([0x3f,0x00]), expectedResponseLength: 256)
+        let cmd : NFCISO7816APDU = NFCISO7816APDU(instructionClass: 0x00, instructionCode: 0xA4, p1Parameter: 0x00, p2Parameter: 0x0C, data: Data([0x3f,0x00]), expectedResponseLength: -1)
         
         _ = try await send( cmd: cmd)
             
@@ -234,7 +234,7 @@ public class TagReader {
     func selectPassportApplication() async throws -> ResponseAPDU {
         // Finally reselect the eMRTD application so the rest of the reading works as normal
         Log.debug( "Re-selecting eMRTD Application" )
-        let cmd : NFCISO7816APDU = NFCISO7816APDU(instructionClass: 0x00, instructionCode: 0xA4, p1Parameter: 0x04, p2Parameter: 0x0C, data: Data([0xA0, 0x00, 0x00, 0x02, 0x47, 0x10, 0x01]), expectedResponseLength: 256)
+        let cmd : NFCISO7816APDU = NFCISO7816APDU(instructionClass: 0x00, instructionCode: 0xA4, p1Parameter: 0x04, p2Parameter: 0x0C, data: Data([0xA0, 0x00, 0x00, 0x02, 0x47, 0x10, 0x01]), expectedResponseLength: -1)
         
         let response = try await self.send( cmd: cmd)
         return response


### PR DESCRIPTION
I noticed, that I was not able to successfully authenticate using PACE with German passports. I then compared the commands and responses with the ones JMRTD produces and found out, that NFCPassportReader sends an expected result length (LE) with some commands, while JMRTD does not.
According to the ICAO specs, these commands (INS 0xA4 and 0x22) should not have an LE field at all. While some passports seem to ignore that, all German documents, I tested it with, do not - and therefore fall back to BAC.

I tested the changes with 6 German documents (2008 - 2022), two Dutch (2006, 2020), a Croatian (2018) and a Turkish one (2021). All worked reliably with the changes.