### PR TITLE
CAN support for PACE version 2

### DIFF
--- a/Sources/NFCPassportReader/BACHandler.swift
+++ b/Sources/NFCPassportReader/BACHandler.swift
@@ -55,7 +55,7 @@ public class BACHandler {
         let maResponse = try await tagReader.doMutualAuthentication(cmdData: Data(cmd_data))
         Log.debug( "DATA - \(maResponse.data)" )
         guard maResponse.data.count > 0 else {
-            throw NFCPassportReaderError.InvalidMRZKey
+            throw NFCPassportReaderError.AuthenticationFailed
         }
         
         let (KSenc, KSmac, ssc) = try self.sessionKeys(data: [UInt8](maResponse.data))

--- a/Sources/NFCPassportReader/Errors.swift
+++ b/Sources/NFCPassportReader/Errors.swift
@@ -31,7 +31,7 @@ public enum NFCPassportReaderError: Error {
     case TagNotValid
     case ConnectionError
     case UserCanceled
-    case InvalidMRZKey
+    case AuthenticationFailed
     case MoreThanOneTagFound
     case InvalidHashAlgorithmSpecified
     case UnsupportedCipherAlgorithm
@@ -63,7 +63,7 @@ public enum NFCPassportReaderError: Error {
             case .TagNotValid: return "TagNotValid"
             case .ConnectionError: return "ConnectionError"
             case .UserCanceled: return "UserCanceled"
-            case .InvalidMRZKey: return "InvalidMRZKey"
+            case .AuthenticationFailed: return "AuthenticationFailed"
             case .MoreThanOneTagFound: return "MoreThanOneTagFound"
             case .InvalidHashAlgorithmSpecified: return "InvalidHashAlgorithmSpecified"
             case .UnsupportedCipherAlgorithm: return "UnsupportedCipherAlgorithm"

--- a/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
+++ b/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
@@ -36,8 +36,8 @@ extension NFCViewDisplayMessage {
                         return "More than 1 tags was found. Please present only 1 tag."
                     case NFCPassportReaderError.ConnectionError:
                         return "Connection error. Please try again."
-                    case NFCPassportReaderError.InvalidMRZKey:
-                        return "MRZ Key not valid for this document."
+                    case NFCPassportReaderError.AuthenticationFailed:
+                        return "MRZ or CAN Key not valid for this document."
                     case NFCPassportReaderError.ResponseError(let description, let sw1, let sw2):
                         return "Sorry, there was a problem reading the passport. \(description) - (0x\(sw1), 0x\(sw2)"
                     default:

--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -14,6 +14,12 @@ import CoreNFC
 import CryptoKit
 
 @available(iOS 15, *)
+public enum PACEAccessKey {
+    case mrz(String)
+    case can(String)
+}
+
+@available(iOS 15, *)
 private enum PACEHandlerError {
     case DHKeyAgreementError(String)
     case ECDHKeyAgreementError(String)
@@ -39,7 +45,7 @@ public class PACEHandler {
     
     
     private static let MRZ_PACE_KEY_REFERENCE : UInt8 = 0x01
-    private static let CAN_PACE_KEY_REFERENCE : UInt8 = 0x02 // Not currently supported
+    private static let CAN_PACE_KEY_REFERENCE : UInt8 = 0x02
     private static let PIN_PACE_KEY_REFERENCE : UInt8 = 0x03 // Not currently supported
     private static let CUK_PACE_KEY_REFERENCE : UInt8 = 0x04 // Not currently supported
 
@@ -71,7 +77,7 @@ public class PACEHandler {
         isPACESupported = true
     }
     
-    public func doPACE( mrzKey : String ) async throws {
+    public func doPACE( accessKey : PACEAccessKey ) async throws {
         guard isPACESupported else {
             throw NFCPassportReaderError.NotYetSupported( "PACE not supported" )
         }
@@ -87,9 +93,15 @@ public class PACEHandler {
         digestAlg = try paceInfo.getDigestAlgorithm()  // Either SHA-1 or SHA-256.
         keyLength = try paceInfo.getKeyLength()  // Get key length  the enc cipher. Either 128, 192, or 256.
 
-        paceKeyType = PACEHandler.MRZ_PACE_KEY_REFERENCE
-        paceKey = try createPaceKey( from: mrzKey )
-        
+        switch accessKey {
+        case .mrz(let mrzKey):
+            paceKeyType = PACEHandler.MRZ_PACE_KEY_REFERENCE
+            paceKey = try createPaceKey( mrzKey: mrzKey )
+        case .can(let canKey):
+            paceKeyType = PACEHandler.CAN_PACE_KEY_REFERENCE
+            paceKey = try createPaceKey( canKey: canKey)
+        }
+
         // Temporary logging
         Log.verbose("doPace - inpit parameters" )
         Log.verbose("paceOID - \(paceOID)" )
@@ -99,7 +111,7 @@ public class PACEHandler {
         Log.verbose("cipherAlg - \(cipherAlg)" )
         Log.verbose("digestAlg - \(digestAlg)" )
         Log.verbose("keyLength - \(keyLength)" )
-        Log.verbose("keyLength - \(mrzKey)" )
+        Log.verbose("paceKeyType - \(paceKeyType)" )
         Log.verbose("paceKey - \(binToHexRep(paceKey, asArray:true))" )
 
         // First start the initial auth call
@@ -581,12 +593,23 @@ extension PACEHandler {
     /// Computes a key seed based on an MRZ key
     /// - Parameter the mrz key
     /// - Returns a encoded key based on the mrz key that can be used for PACE
-    func createPaceKey( from mrzKey: String ) throws -> [UInt8] {
+    func createPaceKey( mrzKey: String ) throws -> [UInt8] {
         let buf: [UInt8] = Array(mrzKey.utf8)
         let hash = calcSHA1Hash(buf)
         
         let smskg = SecureMessagingSessionKeyGenerator()
-        let key = try smskg.deriveKey(keySeed: hash, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: nil, mode: .PACE_MODE, paceKeyReference: paceKeyType)
+        let key = try smskg.deriveKey(keySeed: hash, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: nil, mode: .PACE_MODE, paceKeyReference: PACEHandler.MRZ_PACE_KEY_REFERENCE)
+        return key
+    }
+
+    /// Computes a key seed based on an CAN key
+    /// - Parameter the CAN key
+    /// - Returns a encoded key based on the CAN key that can be used for PACE
+    func createPaceKey( canKey: String ) throws -> [UInt8] {
+        let buf: [UInt8] = Array(canKey.utf8)
+
+        let smskg = SecureMessagingSessionKeyGenerator()
+        let key = try smskg.deriveKey(keySeed: buf, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: nil, mode: .PACE_MODE, paceKeyReference: PACEHandler.CAN_PACE_KEY_REFERENCE)
         return key
     }
     

--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -150,7 +150,7 @@ public class PACEHandler {
 */
     }
     
-    /// Performs PACE Step 1- receives an encrypted nonce from the passport and decypts it with the  PACE key - derived from MRZ, CAN (not yet supported)
+    /// Performs PACE Step 1- receives an encrypted nonce from the passport and decypts it with the  PACE key - derived from MRZ or CAN
     func doStep1() async throws -> [UInt8] {
         Log.debug("Doing PACE Step1...")
         let response = try await tagReader.sendGeneralAuthenticate(data: [], isLast: false)

--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -267,18 +267,15 @@ public class TagReader {
             Log.verbose(String(format:"TagReader [unprotected] \(binToHexRep(rep.data, asArray:true)), sw1:0x%02x sw2:0x%02x", rep.sw1, rep.sw2) )
             
         }
-        
-        if rep.sw1 != 0x90 && rep.sw2 != 0x00 {
+
+        if rep.sw1 == 0x63 && rep.sw2 == 0x00 {
+            Log.error( "TagReader - Authentication failed" )
+            throw NFCPassportReaderError.AuthenticationFailed
+        } else if rep.sw1 != 0x90 && rep.sw2 != 0x00 {
             Log.error( "Error reading tag: sw1 - 0x\(binToHexRep(sw1)), sw2 - 0x\(binToHexRep(sw2))" )
-            let tagError: NFCPassportReaderError
-            if (rep.sw1 == 0x63 && rep.sw2 == 0x00) {
-                tagError = NFCPassportReaderError.InvalidMRZKey
-            } else {
-                let errorMsg = self.decodeError(sw1: rep.sw1, sw2: rep.sw2)
-                Log.error( "reason: \(errorMsg)" )
-                tagError = NFCPassportReaderError.ResponseError( errorMsg, sw1, sw2 )
-            }
-            throw tagError
+            let errorMsg = self.decodeError(sw1: rep.sw1, sw2: rep.sw2)
+            Log.error( "reason: \(errorMsg)" )
+            throw NFCPassportReaderError.ResponseError( errorMsg, sw1, sw2 )
         }
 
         return rep


### PR DESCRIPTION
## Summary

Card Access Number can be used for PACE

This is heavily inspired by #106, which I tried to rebase onto current main branch, but eventually decided to patch it by hand, because there was conflicts that I couldn't resolve in reasonable time.

As opposed to #106, there's some changes in error handling, which in our tests can detect if CAN was invalid.

We've tested the changes successfully with a couple of Finnish passports, on iOS 16.

## Changes

- Add `PACEAccessKey` enum, which can either be `.mrz` or `.can`
- Original `PassportReader.readPassport()` now uses `PACEAccessKey` when establishing PACE.
- `PassportReader.startReading()` doesn't fallback to BAC when PACE fails, if CAN was used.
- Keep old version of `PassportReader.readPassport( mrzKey: ...)` as deprecated overload of `readPassport( accessKey: ...)`. Not sure if this makes sense, because of the next bullet point...
- **BREAKING**: Replace `NFCPassportReaderError.InvalidMRZKey` with `NFCPassportReaderError.AuthenticationFailed`, to indicate that either CAN or MRZ was incorrect.
- Change error handling in `TagReader.send`, to handle authentication error when using incorrect CAN

## Caveats

- As of writing, this is a breaking change, because `NFCPassportReaderError.InvalidMRZKey` is removed
- Example apps do not demonstrate CAN functionality, as is done in #106
- I'm not a PACE expert, nor have previous experience with developing this library, so there might be other things as well that I've overlooked.

## Remarks

I checked the SPM example, and it's pinned to older version of the library. Perhaps the example should be changed so that it uses local version of NFCPassportReader package, to make it easier to develop the example along with the changes to library?