### PR TITLE
Introduced a new display message

### DIFF
--- a/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
+++ b/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
@@ -13,6 +13,7 @@ public enum NFCViewDisplayMessage {
     case authenticatingWithPassport(Int)
     case readingDataGroupProgress(DataGroupId, Int)
     case error(NFCPassportReaderError)
+    case activeAuthentication
     case successfulRead
 }
 
@@ -43,6 +44,8 @@ extension NFCViewDisplayMessage {
                     default:
                         return "Sorry, there was a problem reading the passport. Please try again"
                 }
+            case .activeAuthentication:
+                return "Authenticating....."
             case .successfulRead:
                 return "Passport read successfully"
         }

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -246,10 +246,10 @@ extension PassportReader {
         
         // Now to read the datagroups
         try await readDataGroups(tagReader: tagReader)
-        
-        self.updateReaderSessionMessage(alertMessage: NFCViewDisplayMessage.successfulRead)
 
         try await doActiveAuthenticationIfNeccessary(tagReader : tagReader)
+
+        self.updateReaderSessionMessage(alertMessage: NFCViewDisplayMessage.successfulRead)
         self.shouldNotReportNextReaderSessionInvalidationErrorUserCanceled = true
         self.readerSession?.invalidate()
 
@@ -264,7 +264,9 @@ extension PassportReader {
         guard self.passport.activeAuthenticationSupported else {
             return
         }
-        
+
+        self.updateReaderSessionMessage(alertMessage: NFCViewDisplayMessage.activeAuthentication)
+
         Log.info( "Performing Active Authentication" )
         
         let challenge = generateRandomUInt8Array(8)


### PR DESCRIPTION
During testing integration with this library, we noticed that users were sometimes getting errors because they saw the "Passport read successfully" message (but **not** the checkmark) and then moved their phone away from the NFC chip, resulting in a read error.

It appears that this is due to the active authentication taking a bit of time to complete, and so it would seem useful to introduce messaging for this state before showing the "Passport read successfully" message.

An alternative approach would be:
* Keep `successfulRead` state change in it's current location, but change existing message to appear less "final"
* Add `activeAuthentication` state
* Add a new "final" state (name and message to be determined) to show after `successfulRead` and `activeAuthentication` have finished