### PR TITLE
Master List extract script update

### DIFF
--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -34,12 +34,14 @@ def main( filename ):
         masterLists = readInMasterListFile( filename )
 
     print( f"Read in {len(masterLists)} masterlist files" )
-    print( f"Read in {cns} CNS" )
+    if filename.lower().endswith( ".ldif" ):
+        print( f"Read in {cns} CNS" )
 
     for index, ml in enumerate(masterLists):
         certNr = 1
         print( "-----------------------------------" )
-        print(f"Verifying and extracting MasterList {index} - {cns[index]}")
+        if filename.lower().endswith( ".ldif" ):
+            print(f"Verifying and extracting MasterList {index} - {cns[index]}")
         try:
             extractCertsFromMasterlist( ml )
         except Exception as e:
@@ -60,7 +62,7 @@ def readAndExtractLDIFFile( file ):
         for line in inf:
             if line.startswith( "cn: "):
                 cn = line[4:]
-            elif line.startswith( "CscaMasterListData:: "):
+            elif line.startswith( "CscaMasterListData:: ") or line.startswith( "pkdMasterListContent:: "):
                 cert = line[21:]
                 adding = True
             elif not line.startswith(" ") and adding == True:


### PR DESCRIPTION
ICAO changed master list structure a little bit, so I updated the script to make it work with the latest ICAO Master List (I tried `icaopkd-002-ml-000222.ldif`), while also supporting the old "format".

Also added if statement for prints (if you extracting certificates from `.ml` there is no `cns` variable and it throws an `UnboundLocalError: local variable 'cns' referenced before assignment`)

Thanks!

(I have Python 3.10.9)