### PR TITLE
Improve error reporting of invalid response

### DIFF
--- a/Examples/Example_CocoaPods/NFCPassportReaderAppTests/DataGroupParsingTests.swift
+++ b/Examples/Example_CocoaPods/NFCPassportReaderAppTests/DataGroupParsingTests.swift
@@ -143,12 +143,47 @@ final class DataGroupParsingTests: XCTestCase {
 
         }
     }
-    
+
+    func testItShouldThrowAnErrorWhenActualTagDoesNotMatchExpectedTag() throws {
+        let sut = try DataGroup([1, 2])
+        let expected = 1
+        let actual = 2
+
+        XCTAssertThrowsError(try sut.verifyTag(actual, equals: expected)) { error in
+            XCTAssertEqual("InvalidResponse in Unknown. Expected: 01 Actual: 02", error.localizedDescription)
+        }
+    }
+
+    func testItShouldNotThrowAnErrorWhenActualTagMatchesExpectedTag() throws {
+        let sut = try DataGroup([1, 2])
+        let expected = 1
+        let actual = 1
+
+        XCTAssertNoThrow(try sut.verifyTag(actual, equals: expected))
+    }
+
+    func testItShouldThrowAnErrorWhenActualTagIsNotAnExpectedTag() throws {
+        let sut = try DataGroup([1, 2])
+        let expected = [1, 3]
+        let actual = 2
+
+        XCTAssertThrowsError(try sut.verifyTag(actual, oneOf: expected)) { error in
+            XCTAssertEqual("InvalidResponse in Unknown. Expected: 01 Actual: 02", error.localizedDescription)
+        }
+    }
+
+    func testItShouldNotThrowAnErrorWhenActualTagIsAnExpectedTag() throws {
+        let sut = try DataGroup([1, 2])
+        let expected = [1, 3]
+        let actual = 3
+
+        XCTAssertNoThrow(try sut.verifyTag(actual, oneOf: expected))
+    }
+
     static var allTests = [
         ("testDatagroup1Parsing", testDatagroup1Parsing),
         ("testDatagroup2Parsing", testDatagroup2ParsingJPEG2000),
         ("testDatagroup2ParsingJPEG", testDatagroup2ParsingJPEG),
-        ("testCOMDatagroupParsing", testCOMDatagroupParsing),
+        ("testCOMDatagroupParsing", testCOMDatagroupParsing)
     ]
-    
 }

--- a/Examples/Example_SPM/NFCPassportReaderAppTests/DataGroupParsingTests.swift
+++ b/Examples/Example_SPM/NFCPassportReaderAppTests/DataGroupParsingTests.swift
@@ -143,7 +143,43 @@ final class DataGroupParsingTests: XCTestCase {
 
         }
     }
-    
+
+    func testItShouldThrowAnErrorWhenActualTagDoesNotMatchExpectedTag() throws {
+        let sut = try DataGroup([1, 2])
+        let expected = 1
+        let actual = 2
+
+        XCTAssertThrowsError(try sut.verifyTag(actual, equals: expected)) { error in
+            XCTAssertEqual("InvalidResponse in Unknown. Expected: 01 Actual: 02", error.localizedDescription)
+        }
+    }
+
+    func testItShouldNotThrowAnErrorWhenActualTagMatchesExpectedTag() throws {
+        let sut = try DataGroup([1, 2])
+        let expected = 1
+        let actual = 1
+
+        XCTAssertNoThrow(try sut.verifyTag(actual, equals: expected))
+    }
+
+    func testItShouldThrowAnErrorWhenActualTagIsNotAnExpectedTag() throws {
+        let sut = try DataGroup([1, 2])
+        let expected = [1, 3]
+        let actual = 2
+
+        XCTAssertThrowsError(try sut.verifyTag(actual, oneOf: expected)) { error in
+            XCTAssertEqual("InvalidResponse in Unknown. Expected: 01 Actual: 02", error.localizedDescription)
+        }
+    }
+
+    func testItShouldNotThrowAnErrorWhenActualTagIsAnExpectedTag() throws {
+        let sut = try DataGroup([1, 2])
+        let expected = [1, 3]
+        let actual = 3
+
+        XCTAssertNoThrow(try sut.verifyTag(actual, oneOf: expected))
+    }
+
     static var allTests = [
         ("testDatagroup1Parsing", testDatagroup1Parsing),
         ("testDatagroup2Parsing", testDatagroup2ParsingJPEG2000),

--- a/Sources/NFCPassportReader/DataGroups/COM.swift
+++ b/Sources/NFCPassportReader/DataGroups/COM.swift
@@ -20,10 +20,8 @@ public class COM : DataGroup {
     
     override func parse(_ data: [UInt8]) throws {
         var tag = try getNextTag()
-        if tag != 0x5F01 {
-            throw NFCPassportReaderError.InvalidResponse
-        }
-        
+        try verifyTag(tag, equals: 0x5F01)
+
         // Version is 4 bytes (ascii) - AABB
         // AA is major number, BB is minor number
         // e.g.  48 49 48 55 -> 01 07 -> 1.7
@@ -36,9 +34,7 @@ public class COM : DataGroup {
             }
         }
         tag = try getNextTag()
-        if tag != 0x5F36 {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0x5F36)
         
         versionBytes = try getNextValue()
         if versionBytes.count == 6 {
@@ -51,9 +47,7 @@ public class COM : DataGroup {
         }
         
         tag = try getNextTag()
-        if tag != 0x5C {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0x5C)
         
         let vals = try getNextValue()
         for v in vals {

--- a/Sources/NFCPassportReader/DataGroups/COM.swift
+++ b/Sources/NFCPassportReader/DataGroups/COM.swift
@@ -11,10 +11,11 @@ public class COM : DataGroup {
     public private(set) var version : String = "Unknown"
     public private(set) var unicodeVersion : String = "Unknown"
     public private(set) var dataGroupsPresent : [String] = []
-    
+
+    public override var datagroupType: DataGroupId { .COM }
+
     required init( _ data : [UInt8] ) throws {
         try super.init(data)
-        datagroupType = .COM
     }
     
     override func parse(_ data: [UInt8]) throws {

--- a/Sources/NFCPassportReader/DataGroups/DataGroup.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup.swift
@@ -8,7 +8,7 @@ import Foundation
 
 @available(iOS 13, macOS 10.15, *)
 public class DataGroup {
-    public var datagroupType : DataGroupId = .Unknown
+    public var datagroupType : DataGroupId { .Unknown }
     
     /// Body contains the actual data
     public private(set) var body : [UInt8] = []

--- a/Sources/NFCPassportReader/DataGroups/DataGroup.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup.swift
@@ -80,5 +80,24 @@ public class DataGroup {
         
         return ret
     }
-    
+
+    public func verifyTag(_ tag: Int, equals expectedTag: Int) throws {
+        if tag != expectedTag  {
+            throw NFCPassportReaderError.InvalidResponse(
+                dataGroupId: datagroupType,
+                expectedTag: expectedTag,
+                actualTag: tag
+            )
+        }
+    }
+
+    public func verifyTag(_ tag: Int, oneOf expectedTags: [Int]) throws {
+        if !expectedTags.contains(tag) {
+            throw NFCPassportReaderError.InvalidResponse(
+                dataGroupId: datagroupType,
+                expectedTag: expectedTags.first!,
+                actualTag: tag
+            )
+        }
+    }
 }

--- a/Sources/NFCPassportReader/DataGroups/DataGroup1.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup1.swift
@@ -31,9 +31,7 @@ public class DataGroup1 : DataGroup {
     
     override func parse(_ data: [UInt8]) throws {
         let tag = try getNextTag()
-        if tag != 0x5F1F {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0x5F1F)
         let body = try getNextValue()
         let docType = getMRZType(length:body.count)
         

--- a/Sources/NFCPassportReader/DataGroups/DataGroup1.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup1.swift
@@ -21,12 +21,12 @@ public enum DocTypeEnum: String {
 
 @available(iOS 13, macOS 10.15, *)
 public class DataGroup1 : DataGroup {
-    
     public private(set) var elements : [String:String] = [:]
+
+    public override var datagroupType: DataGroupId { .DG1 }
     
     required init( _ data : [UInt8] ) throws {
         try super.init(data)
-        datagroupType = .DG1
     }
     
     override func parse(_ data: [UInt8]) throws {

--- a/Sources/NFCPassportReader/DataGroups/DataGroup11.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup11.swift
@@ -30,9 +30,7 @@ public class DataGroup11 : DataGroup {
 
     override func parse(_ data: [UInt8]) throws {
         var tag = try getNextTag()
-        if tag != 0x5C {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0x5C)
         _ = try getNextValue()
         
         repeat {

--- a/Sources/NFCPassportReader/DataGroups/DataGroup11.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup11.swift
@@ -21,12 +21,13 @@ public class DataGroup11 : DataGroup {
     public private(set) var proofOfCitizenship : String?
     public private(set) var tdNumbers : String?
     public private(set) var custodyInfo : String?
-    
+
+    public override var datagroupType: DataGroupId { .DG11 }
+
     required init( _ data : [UInt8] ) throws {
         try super.init(data)
-        datagroupType = .DG11
     }
-    
+
     override func parse(_ data: [UInt8]) throws {
         var tag = try getNextTag()
         if tag != 0x5C {

--- a/Sources/NFCPassportReader/DataGroups/DataGroup12.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup12.swift
@@ -26,10 +26,8 @@ public class DataGroup12 : DataGroup {
 
     override func parse(_ data: [UInt8]) throws {
         var tag = try getNextTag()
-        if tag != 0x5C {
-            throw NFCPassportReaderError.InvalidResponse
-        }
-        
+        try verifyTag(tag, equals: 0x5C)
+
         // Skip the taglist - ideally we would check this but...
         let _ = try getNextValue()
         

--- a/Sources/NFCPassportReader/DataGroups/DataGroup12.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup12.swift
@@ -8,7 +8,6 @@ import Foundation
 
 @available(iOS 13, macOS 10.15, *)
 public class DataGroup12 : DataGroup {
-    
     public private(set) var issuingAuthority : String?
     public private(set) var dateOfIssue : String?
     public private(set) var otherPersonsDetails : String?
@@ -18,12 +17,13 @@ public class DataGroup12 : DataGroup {
     public private(set) var rearImage : [UInt8]?
     public private(set) var personalizationTime : String?
     public private(set) var personalizationDeviceSerialNr : String?
-    
+
+    public override var datagroupType: DataGroupId { .DG12 }
+
     required init( _ data : [UInt8] ) throws {
         try super.init(data)
-        datagroupType = .DG12
     }
-    
+
     override func parse(_ data: [UInt8]) throws {
         var tag = try getNextTag()
         if tag != 0x5C {

--- a/Sources/NFCPassportReader/DataGroups/DataGroup14.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup14.swift
@@ -15,10 +15,11 @@ import Foundation
 public class DataGroup14 : DataGroup {
     private var asn1 : ASN1Item!
     public private(set) var securityInfos : [SecurityInfo] = [SecurityInfo]()
+
+    public override var datagroupType: DataGroupId { .DG14 }
     
     required init( _ data : [UInt8] ) throws {
         try super.init(data)
-        datagroupType = .DG14
     }
     
     override func parse(_ data: [UInt8]) throws {

--- a/Sources/NFCPassportReader/DataGroups/DataGroup15.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup15.swift
@@ -12,7 +12,9 @@ public class DataGroup15 : DataGroup {
     
     public private(set) var rsaPublicKey : OpaquePointer?
     public private(set) var ecdsaPublicKey : OpaquePointer?
-    
+
+    public override var datagroupType: DataGroupId { .DG15 }
+
     deinit {
         if ( ecdsaPublicKey != nil ) {
             EVP_PKEY_free(ecdsaPublicKey);
@@ -24,7 +26,6 @@ public class DataGroup15 : DataGroup {
     
     required init( _ data : [UInt8] ) throws {
         try super.init(data)
-        datagroupType = .DG15
     }
     
     

--- a/Sources/NFCPassportReader/DataGroups/DataGroup2.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup2.swift
@@ -34,8 +34,9 @@ public class DataGroup2 : DataGroup {
     public private(set) var deviceType : Int = 0
     public private(set) var quality : Int = 0
     public private(set) var imageData : [UInt8] = []
-    
-    
+
+    public override var datagroupType: DataGroupId { .DG2 }
+
 #if !os(macOS)
 func getImage() -> UIImage? {
         if imageData.count == 0 {
@@ -49,9 +50,8 @@ func getImage() -> UIImage? {
 
     required init( _ data : [UInt8] ) throws {
         try super.init(data)
-        datagroupType = .DG2
     }
-    
+
     override func parse(_ data: [UInt8]) throws {
         var tag = try getNextTag()
         if tag != 0x7F61 {

--- a/Sources/NFCPassportReader/DataGroups/DataGroup2.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup2.swift
@@ -54,37 +54,27 @@ func getImage() -> UIImage? {
 
     override func parse(_ data: [UInt8]) throws {
         var tag = try getNextTag()
-        if tag != 0x7F61 {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0x7F61)
         _ = try getNextLength()
         
         // Tag should be 0x02
         tag = try getNextTag()
-        if  tag != 0x02 {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0x02)
         nrImages = try Int(getNextValue()[0])
         
         // Next tag is 0x7F60
         tag = try getNextTag()
-        if tag != 0x7F60 {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0x7F60)
         _ = try getNextLength()
         
         // Next tag is 0xA1 (Biometric Header Template) - don't care about this
         tag = try getNextTag()
-        if tag != 0xA1 {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0xA1)
         _ = try getNextValue()
         
         // Now we get to the good stuff - next tag is either 5F2E or 7F2E
         tag = try getNextTag()
-        if tag != 0x5F2E && tag != 0x7F2E {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, oneOf: [0x5F2E, 0x7F2E])
         let value = try getNextValue()
         
         try parseISO19794_5( data:value )
@@ -93,7 +83,11 @@ func getImage() -> UIImage? {
     func parseISO19794_5( data : [UInt8] ) throws {
         // Validate header - 'F', 'A' 'C' 0x00 - 0x46414300
         if data[0] != 0x46 && data[1] != 0x41 && data[2] != 0x43 && data[3] != 0x00 {
-            throw NFCPassportReaderError.InvalidResponse
+            throw NFCPassportReaderError.InvalidResponse(
+                dataGroupId: datagroupType,
+                expectedTag: 0x46,
+                actualTag: Int(data[0])
+            )
         }
         
         var offset = 4

--- a/Sources/NFCPassportReader/DataGroups/DataGroup7.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup7.swift
@@ -35,15 +35,11 @@ public class DataGroup7 : DataGroup {
     
     override func parse(_ data: [UInt8]) throws {
         var tag = try getNextTag()
-        if tag != 0x02 {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0x02)
         _ = try getNextValue()
         
         tag = try getNextTag()
-        if tag != 0x5F43 {
-            throw NFCPassportReaderError.InvalidResponse
-        }
+        try verifyTag(tag, equals: 0x5F43)
         
         imageData = try getNextValue()
     }

--- a/Sources/NFCPassportReader/DataGroups/DataGroup7.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup7.swift
@@ -14,10 +14,11 @@ import UIKit
 public class DataGroup7 : DataGroup {
     
     public private(set) var imageData : [UInt8] = []
-    
+
+    public override var datagroupType: DataGroupId { .DG7 }
+
     required init( _ data : [UInt8] ) throws {
         try super.init(data)
-        datagroupType = .DG7
     }
     
 #if !os(macOS)

--- a/Sources/NFCPassportReader/DataGroups/NotImplementedDG.swift
+++ b/Sources/NFCPassportReader/DataGroups/NotImplementedDG.swift
@@ -7,10 +7,10 @@
 import Foundation
 
 @available(iOS 13, macOS 10.15, *)
-public class NotImplementedDG : DataGroup {
-    required init( _ data : [UInt8] ) throws {
+public class NotImplementedDG: DataGroup {
+    override public var datagroupType: DataGroupId { .Unknown }
+
+    required init(_ data: [UInt8]) throws {
         try super.init(data)
-        datagroupType = .Unknown
     }
 }
-

--- a/Sources/NFCPassportReader/DataGroups/SOD.swift
+++ b/Sources/NFCPassportReader/DataGroups/SOD.swift
@@ -65,11 +65,12 @@ class SOD : DataGroup {
     public private(set) var pkcs7CertificateData : [UInt8] = []
     private var asn1 : ASN1Item!
     private var pubKey : OpaquePointer?
+
+    override var datagroupType: DataGroupId { .SOD }
     
     required init( _ data : [UInt8] ) throws {
         try super.init(data)
         self.pkcs7CertificateData = body
-        datagroupType = .SOD
     }
     
     deinit {

--- a/Sources/NFCPassportReader/Errors.swift
+++ b/Sources/NFCPassportReader/Errors.swift
@@ -40,6 +40,7 @@ public enum NFCPassportReaderError: Error {
     case ChipAuthenticationFailed
     case InvalidDataPassed(String)
     case NotYetSupported(String)
+    case Unknown(Error)
 
     var value: String {
         switch self {
@@ -73,6 +74,7 @@ public enum NFCPassportReaderError: Error {
             case .ChipAuthenticationFailed: return "ChipAuthenticationFailed"
             case .InvalidDataPassed(let reason) : return "Invalid data passed - \(reason)"
             case .NotYetSupported(let reason) : return "Not yet supported - \(reason)"
+            case .Unknown(let error): return "Unknown error: \(error.localizedDescription)"
         }
     }
 }

--- a/Sources/NFCPassportReader/Errors.swift
+++ b/Sources/NFCPassportReader/Errors.swift
@@ -12,7 +12,7 @@ import Foundation
 @available(iOS 13, macOS 10.15, *)
 public enum NFCPassportReaderError: Error {
     case ResponseError(String, UInt8, UInt8)
-    case InvalidResponse
+    case InvalidResponse(dataGroupId: DataGroupId, expectedTag: Int, actualTag: Int)
     case UnexpectedError
     case NFCNotSupported
     case NoConnectedTag
@@ -44,7 +44,8 @@ public enum NFCPassportReaderError: Error {
     var value: String {
         switch self {
             case .ResponseError(let errMsg, _, _): return errMsg
-            case .InvalidResponse: return "InvalidResponse"
+            case .InvalidResponse(let dataGroupId, let expected, let actual):
+                return "InvalidResponse in \(dataGroupId.getName()). Expected: \(expected.hexString) Actual: \(actual.hexString)"
             case .UnexpectedError: return "UnexpectedError"
             case .NFCNotSupported: return "NFCNotSupported"
             case .NoConnectedTag: return "NoConnectedTag"

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -198,9 +198,6 @@ extension PassportReader : NFCTagReaderSessionDelegate {
                 let errorMessage = NFCViewDisplayMessage.error(error)
                 self.invalidateSession(errorMessage: errorMessage, error: error)
             } catch let error {
-
-                nfcContinuation?.resume(throwing: error)
-                nfcContinuation = nil
                 Log.debug( "tagReaderSession:failed to connect to tag - \(error.localizedDescription)" )
                 let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.ConnectionError)
                 self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.Unknown(error))

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -203,7 +203,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
                 nfcContinuation = nil
                 Log.debug( "tagReaderSession:failed to connect to tag - \(error.localizedDescription)" )
                 let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.ConnectionError)
-                self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.ConnectionError)
+                self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.Unknown(error))
             }
         }
     }

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -346,6 +346,7 @@ extension PassportReader {
         self.currentlyReadingDataGroup = dgId
         Log.info( "Reading tag - \(dgId)" )
         var readAttempts = 0
+        var nfcPassportReaderError: NFCPassportReaderError
         
         self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.readingDataGroupProgress(dgId, 0) )
 
@@ -356,6 +357,7 @@ extension PassportReader {
                 return dg
             } catch let error as NFCPassportReaderError {
                 Log.error( "TagError reading tag - \(error)" )
+                nfcPassportReaderError = error
 
                 // OK we had an error - depending on what happened, we may want to try to re-read this
                 // E.g. we failed to read the last Datagroup because its protected and we can't
@@ -394,8 +396,9 @@ extension PassportReader {
             }
             readAttempts += 1
         } while ( readAttempts < 2 )
-        
-        return nil
+
+        // The error will be thrown after n attempts
+        throw nfcPassportReaderError
     }
 
     func invalidateSession(errorMessage: NFCViewDisplayMessage, error: NFCPassportReaderError) {

--- a/Sources/NFCPassportReader/Utils.swift
+++ b/Sources/NFCPassportReader/Utils.swift
@@ -21,6 +21,11 @@ private extension UInt8 {
     }
 }
 
+extension Int {
+    var hexString: String {
+        String(format:"%02X", self)
+    }
+}
 
 extension FileManager {
     static var documentDir : URL {


### PR DESCRIPTION
## Changes
- Updated `NFCPassportReaderError.InvalidResponse` to provide more information regarding the datagroup and the read tag
- Added a new error case `Unknown(Error)` to handle errors not directly handled by the SDK
- Added tests to cover the improved output
- `dataGroupType` is now a computed property. This change makes it readonly and also available when an error needs to be thrown in `parse` method
- Fixed an issue in `PassportReader` by removing `nfcContinuation` calls here as this is called in `invalidateSession`

## Background
We experienced problems in capturing which datagroups were responsible for `InvalidResponse` errors. To deal with this the datagroup together with expected and actual tag information is returned back.

## ⚠️ Breaking changes
- Errors that occur in  `PassportReader.readDataGroup(tagReader: TagReader, dgId: DataGroupId)` will now be rethrown instead of being ignored. This is necessary in order to return the error back to the SDK consumer. Personally I think it's better to fail than to return successfully w/o any data, but there might be cases were this is not a good idea.

Resolves #54 

