### PR TITLE
Update extract.py

### DIFF
--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -57,11 +57,12 @@ def readAndExtractLDIFFile( file ):
     cns = []
     cn = ""
     with open(file, "r") as inf:
+        cert = ""
         for line in inf:
             if line.startswith( "cn: "):
                 cn = line[4:]
-            elif line.startswith( "CscaMasterListData:: "):
-                cert = line[21:]
+            elif line.startswith( "pkdMasterListContent:: "):
+                cert = line[23:]
                 adding = True
             elif not line.startswith(" ") and adding == True:
                 adding = False


### PR DESCRIPTION
- Python was throwing an error that the `cert` variable was being accessed before being declared.
- `CscaMasterListData:: ` seems to have been replaced with `pkdMasterListContent:: ` in the master list ldif files from ICAO. This modification fixes the master list pem file creation.