### PR TITLE
Remove arm64 excluded arch related podspecs

### DIFF
--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -19,9 +19,4 @@ Pod::Spec.new do |spec|
   spec.dependency "OpenSSL-Universal", '1.1.1900'
   spec.xcconfig          = { 'OTHER_LDFLAGS' => '-weak_framework CryptoKit -weak_framework CoreNFC -weak_framework CryptoTokenKit' }
 
-  spec.pod_target_xcconfig = {
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-  }
-  spec.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-
 end


### PR DESCRIPTION
This exclusion is outdated since all dependencies support arm64 - therefore excluding it is not needed anymore - it slows down simulator by forcing it running on different architecture on Apple Silicon machines