### PR TITLE
Add tracking delegate and improve error handling

### DIFF
--- a/Sources/NFCPassportReader/Errors.swift
+++ b/Sources/NFCPassportReader/Errors.swift
@@ -30,6 +30,7 @@ public enum NFCPassportReaderError: Error {
     case NotImplemented
     case TagNotValid
     case ConnectionError
+    case TimeOutError
     case UserCanceled
     case InvalidMRZKey
     case MoreThanOneTagFound
@@ -64,6 +65,7 @@ public enum NFCPassportReaderError: Error {
             case .NotImplemented: return "NotImplemented"
             case .TagNotValid: return "TagNotValid"
             case .ConnectionError: return "ConnectionError"
+            case .TimeOutError: return "TimeOutError"
             case .UserCanceled: return "UserCanceled"
             case .InvalidMRZKey: return "InvalidMRZKey"
             case .MoreThanOneTagFound: return "MoreThanOneTagFound"

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -208,7 +208,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
                 if let nfcError = error as? NFCReaderError {
                     // .readerTransceiveErrorTagResponseError is thrown when a "connection lost" scenario is forced by moving the phone away from the NFC chip
                     // .readerTransceiveErrorTagConnectionLost is never thrown for this scenario, but added for the sake of completeness
-                    if nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagResponseError.rawValue || nfc.errorCode == NFCReaderError.readerTransceiveErrorTagConnectionLost.rawValue {
+                    if nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagResponseError.rawValue || nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagConnectionLost.rawValue {
                         let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.ConnectionError)
                         self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.ConnectionError)
                     }

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -14,10 +14,16 @@ import UIKit
 import CoreNFC
 
 @available(iOS 15, *)
+public protocol PassportReaderTrackingDelegate: AnyObject {
+    func nfcTagDetected()
+}
+
+@available(iOS 15, *)
 public class PassportReader : NSObject {
     private typealias NFCCheckedContinuation = CheckedContinuation<NFCPassportModel, Error>
     private var nfcContinuation: NFCCheckedContinuation?
 
+    public weak var trackingDelegate: PassportReaderTrackingDelegate?
     private var passport : NFCPassportModel = NFCPassportModel()
     
     private var readerSession: NFCTagReaderSession?
@@ -290,6 +296,7 @@ extension PassportReader {
     func doBACAuthentication(tagReader : TagReader) async throws {
         self.currentlyReadingDataGroup = nil
         
+        trackingDelegate?.nfcTagDetected()
         Logger.passportReader.info( "Starting Basic Access Control (BAC)" )
         
         self.passport.BACStatus = .failed

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -289,13 +289,10 @@ extension PassportReader {
         if passport.PACEStatus != .success {
             do {
                 trackingDelegate?.bacStarted()
-
                 try await doBACAuthentication(tagReader : tagReader)
-
                 trackingDelegate?.bacSucceeded()
             } catch {
                 trackingDelegate?.bacFailed()
-
                 throw error
             }
         }

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -230,13 +230,13 @@ extension PassportReader : NFCTagReaderSessionDelegate {
             } catch {
                 Logger.passportReader.debug( "tagReaderSession:failed to connect to tag - \(error.localizedDescription)" )
 
-                if let nfcError = error as? NFCReaderError {
-                    // .readerTransceiveErrorTagResponseError is thrown when a "connection lost" scenario is forced by moving the phone away from the NFC chip
-                    // .readerTransceiveErrorTagConnectionLost is never thrown for this scenario, but added for the sake of completeness
-                    if nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagResponseError.rawValue || nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagConnectionLost.rawValue {
-                        let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.ConnectionError)
-                        self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.ConnectionError)
-                    }
+                // .readerTransceiveErrorTagResponseError is thrown when a "connection lost" scenario is forced by moving the phone away from the NFC chip
+                // .readerTransceiveErrorTagConnectionLost is never thrown for this scenario, but added for the sake of completeness
+                if let nfcError = error as? NFCReaderError,
+                   nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagResponseError.rawValue ||
+                    nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagConnectionLost.rawValue {
+                    let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.ConnectionError)
+                    self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.ConnectionError)
                 } else {
                     let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.Unknown(error))
                     self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.Unknown(error))


### PR DESCRIPTION
### Tracking Delegate
Add a tracking delegate for the `PassportReader` to track the detection of an NFC tag and the authentication processes (BAC and PACE). 
We added the tracking to gain insights into the duration of each step, depending on its completion status (success or failure). 

*Note:* There are **no breaking changes**, since the default implementation of the tracking delegate in the `PassportReader` is empty.

### Error Handling
Add more detailed error handling to provide users better feedback on why the reading failed. 

- Add `TimeOutError` when the reader session timed out
- Handle errors properly when the connection to a tag is lost during reading by throwing a `ConnectionError` instead of `Unknown`