### PR TITLE
Add PACE-CAN Authentication Support

### DIFF
--- a/Examples/Example_SPM/NFCPassportReaderApp/Views/MainView.swift
+++ b/Examples/Example_SPM/NFCPassportReaderApp/Views/MainView.swift
@@ -248,25 +248,38 @@ extension MainView {
         appLogging.error( "Using version \(UIApplication.version)" )
         
         Task {
-            let customMessageHandler : (NFCViewDisplayMessage)->String? = { (displayMessage) in
-                switch displayMessage {
-                    case .requestPresentPassport:
-                        return selectedPasswordType == .mrz ?
-                            "Hold your iPhone near an NFC enabled passport." :
-                            "Hold your iPhone near the document and enter the CAN."
-                    default:
-                        // Return nil for all other messages so we use the provided default
-                        return nil
+                let customMessageHandler: (NFCViewDisplayMessage)->String? = { (displayMessage) in
+                    switch displayMessage {
+                        case .requestPresentPassport:
+                            return selectedPasswordType == .mrz ?
+                                "Hold your iPhone near an NFC enabled passport." :
+                                "Hold your iPhone near the document and enter the CAN."
+                        default:
+                            // Return nil for all other messages so we use the provided default
+                            return nil
+                    }
                 }
-            }
-            
-            do {
-                let passport = try await passportReader.readPassport(
-                    mrzKey: mrzKeyParam,
-                    can: canParam,
-                    useExtendedMode: settings.useExtendedMode,
-                    customDisplayMessage: customMessageHandler
-                )
+                
+                do {
+                    let passport: NFCPassportModel
+                    
+                    if selectedPasswordType == .mrz {
+                        // Use the original API for MRZ to demonstrate backward compatibility
+                        passport = try await passportReader.readPassport(
+                            mrzKey: mrzKeyParam,
+                            useExtendedMode: settings.useExtendedMode,
+                            customDisplayMessage: customMessageHandler
+                        )
+                    } else {
+                        // Use the new API for CAN
+                        passport = try await passportReader.readPassport(
+                            mrzKey: nil,
+                            can: canParam,
+                            useExtendedMode: settings.useExtendedMode,
+                            customDisplayMessage: customMessageHandler
+                        )
+                    }
+                    
                 
                 if let _ = passport.faceImageInfo {
                     print( "Got face Image details")

--- a/Sources/NFCPassportReader/Errors.swift
+++ b/Sources/NFCPassportReader/Errors.swift
@@ -78,7 +78,7 @@ public enum NFCPassportReaderError: Error {
             case .InvalidDataPassed(let reason) : return "Invalid data passed - \(reason)"
             case .NotYetSupported(let reason) : return "Not yet supported - \(reason)"
             case .Unknown(let error): return "Unknown error: \(error.localizedDescription)"
-            case .InvalidCAN: return "Invalid CAN format"
+            case .InvalidCAN: return "InvalidCAN"
         }
     }
 }

--- a/Sources/NFCPassportReader/Errors.swift
+++ b/Sources/NFCPassportReader/Errors.swift
@@ -42,6 +42,7 @@ public enum NFCPassportReaderError: Error {
     case InvalidDataPassed(String)
     case NotYetSupported(String)
     case Unknown(Error)
+    case InvalidCAN
 
     var value: String {
         switch self {
@@ -77,6 +78,7 @@ public enum NFCPassportReaderError: Error {
             case .InvalidDataPassed(let reason) : return "Invalid data passed - \(reason)"
             case .NotYetSupported(let reason) : return "Not yet supported - \(reason)"
             case .Unknown(let error): return "Unknown error: \(error.localizedDescription)"
+            case .InvalidCAN: return "Invalid CAN format"
         }
     }
 }

--- a/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
+++ b/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
@@ -40,6 +40,13 @@ extension NFCViewDisplayMessage {
                         return "Connection error. Please try again."
                     case NFCPassportReaderError.InvalidMRZKey:
                         return "MRZ Key not valid for this document."
+                    case NFCPassportReaderError.InvalidCAN:
+                        return "CAN is not valid for this document."
+                    case NFCPassportReaderError.InvalidDataPassed(let reason):
+                        if reason.contains("CAN") {
+                            return "Invalid CAN: \(reason)"
+                        }
+                        return "Invalid data: \(reason)"
                     case NFCPassportReaderError.ResponseError(let description, let sw1, let sw2):
                         return "Sorry, there was a problem reading the passport. \(description) - (0x\(sw1), 0x\(sw2)"
                     default:

--- a/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
+++ b/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
@@ -15,6 +15,7 @@ public enum NFCViewDisplayMessage {
     case error(NFCPassportReaderError)
     case activeAuthentication
     case successfulRead
+    case requestPresentPassportForCAN
 }
 
 @available(iOS 13, macOS 10.15, *)
@@ -48,6 +49,8 @@ extension NFCViewDisplayMessage {
                 return "Authenticating....."
             case .successfulRead:
                 return "Passport read successfully"
+            case .requestPresentPassportForCAN:
+                return "Hold your iPhone near an NFC enabled passport and enter your CAN."
         }
     }
     

--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -35,6 +35,12 @@ extension PACEHandlerError: LocalizedError {
     }
 }
 
+public enum PACEPasswordType {
+    case mrz
+    case can
+    // Other types could be added: PIN, PUK, etc.
+}
+
 @available(iOS 15, *)
 public class PACEHandler {
     
@@ -72,7 +78,7 @@ public class PACEHandler {
         isPACESupported = true
     }
     
-    public func doPACE( mrzKey : String ) async throws {
+    public func doPACE(password: String, passwordType: PACEPasswordType = .mrz) async throws {
         guard isPACESupported else {
             throw NFCPassportReaderError.NotYetSupported( "PACE not supported" )
         }
@@ -88,8 +94,16 @@ public class PACEHandler {
         digestAlg = try paceInfo.getDigestAlgorithm()  // Either SHA-1 or SHA-256.
         keyLength = try paceInfo.getKeyLength()  // Get key length  the enc cipher. Either 128, 192, or 256.
 
-        paceKeyType = PACEHandler.MRZ_PACE_KEY_REFERENCE
-        paceKey = try createPaceKey( from: mrzKey )
+        // Set key reference based on password type
+         switch passwordType {
+         case .mrz:
+             paceKeyType = PACEHandler.MRZ_PACE_KEY_REFERENCE
+         case .can:
+             paceKeyType = PACEHandler.CAN_PACE_KEY_REFERENCE
+         }
+         
+         // Create PACE key with appropriate method based on type
+         paceKey = try createPaceKey(from: password, type: passwordType)
         
         // Temporary logging
         Logger.pace.debug("doPace - inpit parameters" )
@@ -100,7 +114,7 @@ public class PACEHandler {
         Logger.pace.debug("cipherAlg - \(self.cipherAlg)" )
         Logger.pace.debug("digestAlg - \(self.digestAlg)" )
         Logger.pace.debug("keyLength - \(self.keyLength)" )
-        Logger.pace.debug("keyLength - \(mrzKey)" )
+        Logger.pace.debug("keyLength - \(password)" )
         Logger.pace.debug("paceKey - \(binToHexRep(self.paceKey, asArray:true))" )
 
         // First start the initial auth call
@@ -580,15 +594,27 @@ extension PACEHandler {
     }
 
     /// Computes a key seed based on an MRZ key
-    /// - Parameter the mrz key
+    /// - Parameters:
+    ///     - password: The password to be used for PACE
+    ///     - PACEPasswordType: The type of the password for example MRZ, CAN, etc
     /// - Returns a encoded key based on the mrz key that can be used for PACE
-    func createPaceKey( from mrzKey: String ) throws -> [UInt8] {
-        let buf: [UInt8] = Array(mrzKey.utf8)
-        let hash = calcSHA1Hash(buf)
-        
-        let smskg = SecureMessagingSessionKeyGenerator()
-        let key = try smskg.deriveKey(keySeed: hash, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: nil, mode: .PACE_MODE, paceKeyReference: paceKeyType)
-        return key
+    func createPaceKey(from password: String, type: PACEPasswordType) throws -> [UInt8] {
+        switch type {
+        case .mrz:
+            let buf: [UInt8] = Array(password.utf8)
+            let hash = calcSHA1Hash(buf)
+            
+            let smskg = SecureMessagingSessionKeyGenerator()
+            let key = try smskg.deriveKey(keySeed: hash, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: nil, mode: .PACE_MODE, paceKeyReference: paceKeyType)
+            return key
+            
+        case .can:
+            let canBytes: [UInt8] = Array(password.utf8)
+            
+            let smskg = SecureMessagingSessionKeyGenerator()
+            let key = try smskg.deriveKey(keySeed: canBytes, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: nil, mode: .PACE_MODE, paceKeyReference: paceKeyType)
+            return key
+        }
     }
     
     /// Performs the ECDH PACE GM key agreement protocol by multiplying a private key with a public key

--- a/Sources/NFCPassportReader/PACEPasswordValidator.swift
+++ b/Sources/NFCPassportReader/PACEPasswordValidator.swift
@@ -1,0 +1,21 @@
+//
+//  PACEPasswordValidator.swift
+//  NFCPassportReader
+//
+//  Created by Manwel Bugeja Personal on 24/04/2025.
+//
+
+
+class PACEPasswordValidator {
+    static func validate(password: String, type: PACEPasswordType) throws {
+        switch type {
+            case .mrz:
+                // MRZ validation logic if needed
+                break
+            case .can:
+                guard password.count == 6 && password.allSatisfy({ $0.isNumber }) else {
+                    throw NFCPassportReaderError.InvalidDataPassed("CAN must be 6 digits")
+                }
+        }
+    }
+}


### PR DESCRIPTION
# Add PACE-CAN Authentication Support

## Overview
This PR adds support for PACE authentication using Card Access Number (CAN) as an alternative to MRZ. The implementation is non-breaking, maintaining backward compatibility with existing code while adding new functionality.

## Key Changes
- Added support for CAN-based PACE authentication as an alternative to MRZ
- Created a `PACEPasswordType` enum to distinguish between authentication methods
- Added password validation for different authentication types
- Updated UI in sample app to allow users to choose between MRZ and CAN authentication
- Enhanced error handling to provide specific error messages for CAN-related issues
- Updated `NFCViewDisplayMessage` to support CAN-specific display messages

## Implementation Details
- Updated `PassportReader.swift` to accept either MRZ or CAN through the `readPassport` method
- Modified `PACEHandler.swift` to handle different password types
- Added `PACEPasswordValidator.swift` to validate input based on password type
- Updated error handling in `NFCPassportReaderError` with a dedicated `InvalidCAN` case
- Enhanced the sample app UI with a segmented control for authentication method selection

## Backward Compatibility
- Carefully maintained the original API signature for MRZ-based authentication
- Sample app demonstrates both the original API call pattern for MRZ and the new pattern for CAN
- Existing code using MRZ authentication will continue to work without changes

## Benefits
- Supports e-passports and ID cards that require CAN authentication
- Maintains backward compatibility with existing integrations
- Provides clear user feedback for authentication failures
- Improves accessibility of the library by supporting more authentication methods

## Testing
The changes have been tested with both MRZ and CAN authentication methods on supported documents. The sample app has been updated to demonstrate both authentication methods working correctly.

## Screenshots
![IMG_1660](https://github.com/user-attachments/assets/af9088a0-7f86-4d19-bd37-e04965c6aa2e)
![IMG_1659](https://github.com/user-attachments/assets/87ff628e-12f7-4c03-81bb-88a23c21c7b3)
