### PR TITLE
OpenSSL v3 Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .upToNextMinor(from: "3.1.5001")),
+        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .upToNextMinor(from: "3.3.1000")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .upToNextMinor(from: "1.1.2300"))
-
+        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .upToNextMinor(from: "3.1.5001")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/NFCPassportReader/OpenSSLUtils.swift
+++ b/Sources/NFCPassportReader/OpenSSLUtils.swift
@@ -10,6 +10,8 @@ import OSLog
 import OpenSSL
 import CryptoTokenKit
 
+
+
 @available(iOS 13, macOS 10.15, *)
 public class OpenSSLUtils {
     private static var loaded = false
@@ -40,6 +42,18 @@ public class OpenSSLUtils {
         let ret = String(cString:buffer)
         return ret
     }
+    
+
+    static func sk_X509_num(_ sk : OpaquePointer!) -> Int32 {
+        return OPENSSL_sk_num(ossl_check_const_X509_sk_type(sk))
+    }
+    
+    static func sk_X509_value(_ sk : OpaquePointer!, _ idx : Int32 ) -> OpaquePointer! {
+        let p = OPENSSL_sk_value(ossl_check_const_X509_sk_type(sk), (idx))
+        let op = OpaquePointer(p)
+        return op
+    }
+
     
     static func X509ToPEM( x509: OpaquePointer ) -> String {
         
@@ -572,7 +586,7 @@ public class OpenSSLUtils {
     public static func getPublicKeyData(from key:OpaquePointer) -> [UInt8]? {
         var data : [UInt8] = []
         // Get Key type
-        let v = EVP_PKEY_base_id( key )
+        let v = EVP_PKEY_get_base_id( key )
         if v == EVP_PKEY_DH || v == EVP_PKEY_DHX {
             guard let dh = EVP_PKEY_get0_DH(key) else {
                 return nil
@@ -608,7 +622,7 @@ public class OpenSSLUtils {
     public static func decodePublicKeyFromBytes(pubKeyData: [UInt8], params: OpaquePointer) -> OpaquePointer? {
         var pubKey : OpaquePointer?
         
-        let keyType = EVP_PKEY_base_id( params )
+        let keyType = EVP_PKEY_get_base_id( params )
         if keyType == EVP_PKEY_DH || keyType == EVP_PKEY_DHX {
             
             let dhKey = DH_new()
@@ -657,7 +671,7 @@ public class OpenSSLUtils {
         // OR I'm misunderstanding something (which is more possible)
         // Works fine though for ECDH keys
         var secret : [UInt8]
-        let keyType = EVP_PKEY_base_id( privateKeyPair )
+        let keyType = EVP_PKEY_get_base_id( privateKeyPair )
         if keyType == EVP_PKEY_DH || keyType == EVP_PKEY_DHX {
             // Get bn for public key
             let dh = EVP_PKEY_get1_DH(privateKeyPair);
@@ -669,7 +683,7 @@ public class OpenSSLUtils {
             secret = [UInt8](repeating: 0, count: Int(DH_size(dh)))
             let len = DH_compute_key(&secret, bn, dh);
             
-            Logger.openSSL.debug( "OpenSSLUtils.computeSharedSecret - DH secret len - \(len)" )
+            Logger.openSSL.debug( "OpenSSLUtils.computeSharedSecret - DH secret len - \(len) - \(secret)" )
         } else {
             let ctx = EVP_PKEY_CTX_new(privateKeyPair, nil)
             defer{ EVP_PKEY_CTX_free(ctx) }
@@ -698,6 +712,9 @@ public class OpenSSLUtils {
                 // Error
                 Logger.openSSL.error( "ERROR - \(OpenSSLUtils.getOpenSSLError())" )
             }
+            
+            Logger.openSSL.debug( "OpenSSLUtils.computeSharedSecret - secret len - \(keyLen), secret - \(secret)" )
+
         }
         return secret
     }

--- a/Sources/NFCPassportReader/OpenSSLUtils.swift
+++ b/Sources/NFCPassportReader/OpenSSLUtils.swift
@@ -10,8 +10,6 @@ import OSLog
 import OpenSSL
 import CryptoTokenKit
 
-
-
 @available(iOS 13, macOS 10.15, *)
 public class OpenSSLUtils {
     private static var loaded = false

--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -561,7 +561,7 @@ extension PACEHandler {
             throw NFCPassportReaderError.InvalidDataPassed("Unable to get public key data")
         }
 
-        let keyType = EVP_PKEY_base_id( key )
+        let keyType = EVP_PKEY_get_base_id( key )
         let tag : TKTLVTag
         if keyType == EVP_PKEY_DH || keyType == EVP_PKEY_DHX {
             tag = 0x84

--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -107,8 +107,13 @@ public class PACEHandler {
         _ = try await tagReader.sendMSESetATMutualAuth(oid: paceOID, keyType: paceKeyType)
             
         let decryptedNonce = try await self.doStep1()
+
         let ephemeralParams = try await self.doStep2(passportNonce: decryptedNonce)
+        defer { EVP_PKEY_free( ephemeralParams ) }
+
         let (ephemeralKeyPair, passportPublicKey) = try await self.doStep3KeyExchange(ephemeralParams: ephemeralParams)
+        defer { EVP_PKEY_free(ephemeralKeyPair); EVP_PKEY_free(passportPublicKey) }
+
         let (encKey, macKey) = try await self.doStep4KeyAgreement( pcdKeyPair: ephemeralKeyPair, passportPublicKey: passportPublicKey)
         try self.paceCompleted( ksEnc: encKey, ksMac: macKey )
         Logger.pace.debug("PACE SUCCESSFUL" )
@@ -248,21 +253,32 @@ public class PACEHandler {
     func doStep3KeyExchange(ephemeralParams: OpaquePointer) async throws -> (OpaquePointer, OpaquePointer) {
         Logger.pace.debug( "Doing PACE Step3 - Key Exchange")
 
-        // Generate ephemeral keypair from ephemeralParams
-        var ephKeyPair : OpaquePointer? = nil
-        let pctx = EVP_PKEY_CTX_new(ephemeralParams, nil)
-        EVP_PKEY_keygen_init(pctx)
-        EVP_PKEY_keygen(pctx, &ephKeyPair)
-        EVP_PKEY_CTX_free(pctx)
-                
+        // Create a new EC_KEY with the same group
+        guard let ephEcKey = EC_KEY_new() else {
+            throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Failed to create EC key" )
+        }
+        defer { EC_KEY_free(ephEcKey) }
+
+        guard
+            let ecParams = EVP_PKEY_get0_EC_KEY(ephemeralParams),
+            let group = EC_KEY_get0_group(ecParams),
+            EC_KEY_set_group(ephEcKey, group) == 1,
+            EC_KEY_generate_key(ephEcKey) == 1 else {
+            throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Failed to generate EC key" )
+        }
+
+        // Wrap the EC_KEY into an EVP_PKEY
+        var ephKeyPair = EVP_PKEY_new()
         guard let ephemeralKeyPair = ephKeyPair else {
             throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Unable to get create ephermeral key pair" )
         }
+        defer { EVP_PKEY_free(ephKeyPair) }
+
+        guard EVP_PKEY_set1_EC_KEY(ephemeralKeyPair, ephEcKey) == 1 else {
+            throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Failed to set ephemeral key pair private key" )
+        }
         
         Logger.pace.debug( "Generated Ephemeral key pair")
-
-        // We've finished with the ephemeralParams now - we can now free it
-        EVP_PKEY_free( ephemeralParams )
 
         guard let publicKey = OpenSSLUtils.getPublicKeyData( from: ephemeralKeyPair ) else {
             throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Unable to get public key from ephermeral key pair" )
@@ -279,6 +295,7 @@ public class PACEHandler {
         }
 
         Logger.pace.debug( "Received passports ephemeral public key - \(binToHexRep(passportEncodedPublicKey!, asArray: true))" )
+        defer { ephKeyPair = nil } // prevent free to return the value on success path
         return (ephemeralKeyPair, passportPublicKey)
     }
     


### PR DESCRIPTION
# OpenSSL v3 Support

## Overview

Based on the discussion in #217, and specifically comment from [rkyd](https://github.com/AndyQ/NFCPassportReader/issues/217#issuecomment-2538903971) I tried to update PACE handling code to work with new OpenSSL versions. I've been able to test it with EE passport and PT ID card that support PACE to verify that this solution works.

## Changes

* Based on [OpenSSL3](https://github.com/AndyQ/NFCPassportReader/tree/OpenSSL3) branch.
* `PACEHandler:252` - `PACEHandler:256` part rewritten using `EC_KEY_generate_key` to match generator point used by ICC.
* I've tried to ensure correct `free` usage with `defer`s to account for failure branches.