### PR TITLE
Modify Package.swift to require OpenSSL 3.3.3001

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .upToNextMinor(from: "1.1.2300"))
+        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .upToNextMinor(from: "3.3.3001"))
 
     ],
     targets: [


### PR DESCRIPTION
Workaround to allow packages resolution (not an actual update to OpenSSL3, this is applied through patch in Bazel).