### PR TITLE
Added dateOfIssue Parameter in NFCPassportModel.swift

### DIFF
--- a/Sources/NFCPassportReader/NFCPassportModel.swift
+++ b/Sources/NFCPassportReader/NFCPassportModel.swift
@@ -73,6 +73,13 @@ public class NFCPassportModel {
               let telephone = dg11.telephone else { return nil }
         return telephone
     }()
+
+    /// date of issue
+    public private(set) lazy var dateOfIssue : String? = {
+        guard let dg12 = dataGroupsRead[.DG12] as? DataGroup12,
+              let dateOfIssue = dg12.dateOfIssue else { return nil }
+        return dateOfIssue
+    }()
     
     /// personal number
     public private(set) lazy var personalNumber : String? = {


### PR DESCRIPTION
This PR adds support for returning the `dateOfIssue` field in `NFCPassportModel` after a successful NFC scan. The `dateOfIssue` parameter has been added to `NFCPassportModel.swift` to enable enhanced validation use cases.