### PR TITLE
Fix PACE access control failures on eIDs

### DIFF
--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -104,8 +104,8 @@ public class PACEHandler {
         Logger.pace.debug("paceKey - \(binToHexRep(self.paceKey, asArray:true))" )
 
         // First start the initial auth call
-        _ = try await tagReader.sendMSESetATMutualAuth(oid: paceOID, keyType: paceKeyType)
-            
+        _ = try await tagReader.sendMSESetATMutualAuth(oid: paceOID, keyType: paceKeyType, parameterId: paceInfo.getParameterId())
+
         let decryptedNonce = try await self.doStep1()
 
         let ephemeralParams = try await self.doStep2(passportNonce: decryptedNonce)

--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -110,14 +110,17 @@ public class TagReader {
         
         return try await send( cmd: cmd )
     }
-    
-    func sendMSESetATMutualAuth( oid: String, keyType: UInt8 ) async throws -> ResponseAPDU {
-        
+
+    func sendMSESetATMutualAuth( oid: String, keyType: UInt8, parameterId: Int? = nil ) async throws -> ResponseAPDU {
+
         let oidBytes = oidToBytes(oid: oid, replaceTag: true)
         let keyTypeBytes = wrapDO( b: 0x83, arr:[keyType])
         
-        let data = oidBytes + keyTypeBytes
-            
+        var data = oidBytes + keyTypeBytes
+        if let parameterId {
+            data += wrapDO(b: 0x84, arr: [UInt8(parameterId)])
+        }
+
         let cmd = NFCISO7816APDU(instructionClass: 00, instructionCode: 0x22, p1Parameter: 0xC1, p2Parameter: 0xA4, data: Data(data), expectedResponseLength: -1)
         
         return try await send( cmd: cmd )


### PR DESCRIPTION
### 🧾 Summary

I've been struggling with PACE failures for months (specifically German and Polish eIDs) and I finally figured out the issue.

This PR fixes the issue by including the **Parameter ID (tag `0x84`)** in the **MSE SET AT** command when multiple PACE configurations are supported by the card.

This resolves NFC session failures during PACE Step 2 caused by a mismatch between the card’s selected domain parameters and the ones used by the reader (PCD).

---

### 🐛 Problem

Some eIDs (I've personally seen on German / Polish) advertise **multiple PACE configurations** via the `CardAccess` file. Each configuration is represented as a `PACEInfo` entry with a distinct **parameter ID**.

Per spec, this field is technically optional — but in practice, **required when multiple parameter sets exist**.  Omitting causes the reading to fail. 

Without it:
- The card defaults to the *first available parameter set* (typically P-256)
- The existing implementation proceeded using a different set (e.g. P-384)
- This caused a mismatch in expected key sizes during PACE Step 2

Result:
- Card expected: 65-byte public key (P-256)
- We send: 97-byte public key (P-384)
- Card failed to parse → dropped NFC connection
- Observed error: `Tag response error / no response` (no SW returned)

---

### ✅ Solution

Include the **parameter ID (tag `0x84`)** in the MSE SET AT command using the value parsed from `CardAccess`.

#### Before
```
80 ...   ← OID (tag 0x80)
83 01 01 ← key reference (MRZ)
```

#### After
```
80 ...   ← OID (tag 0x80)
83 01 01 ← key reference (MRZ)
84 01 10 ← parameter ID (e.g. 16 = brainpoolP384r1)
```

---

### 🔍 Implementation Details

- `parameterId` is parsed from the ASN.1 `PACEInfo` structure in `CardAccess`
- Stored in `PACEInfo.parameterId`
- Retrieved via `paceInfo.getParameterId()` when building the MSE SET AT APDU

```swift
// SecurityInfo.swift
if let optionalData = optionalData {
    parameterId = Int(optionalData.value, radix: 16)
}
return PACEInfo(oid: oid, version: version, parameterId: parameterId)
```

---

### 🧠 Background

- `CardAccess` contains a list of `SecurityInfo` entries, including one or more `PACEInfo` records
- Each `PACEInfo` defines:
  - Algorithm (via OID)
  - Version
  - Optional parameter ID (domain parameters)

Example:
```
PACEInfo #1: ECDH-GM / AES-128 / brainpoolP256r1  (ID = 13)
PACEInfo #2: ECDH-GM / AES-256 / brainpoolP384r1  (ID = 16)
```

The parameter ID maps to standardized curves defined in **BSI TR-03110**.

---

### ⚠️ Spec vs Reality

- Spec: parameter ID (`0x84`) is *optional*
- Reality: **mandatory when multiple parameter sets are present**

Cards supporting multiple curves cannot infer which one the PCD intends to use — omission leads to undefined behavior (typically fallback to the weakest/default curve).

---

### 🧪 Result

- Correct parameter set is explicitly selected
- Key sizes align between card and PCD
- PACE Step 2 succeeds
- NFC session remains stable (no more silent disconnects)

---
