### PR TITLE
Make primary authentication method (PACE/BAC) configurable

### DIFF
--- a/Examples/Example_SPM/NFCPassportReaderApp/Views/MainView.swift
+++ b/Examples/Example_SPM/NFCPassportReaderApp/Views/MainView.swift
@@ -209,7 +209,7 @@ extension MainView {
             }
             
             do {
-                let passport = try await passportReader.readPassport( mrzKey: mrzKey, skipCA: skipCA, skipPACE: skipPACE, useExtendedMode: useExtendedMode, customDisplayMessage:customMessageHandler)
+                let passport = try await passportReader.readPassport( mrzKey: mrzKey, skipCA: skipCA, authenticationMethod: skipPACE ? .BAC : .PACE, useExtendedMode: useExtendedMode, customDisplayMessage:customMessageHandler)
                 
                 if let _ = passport.faceImageInfo {
                     print( "Got face Image details")

--- a/Sources/NFCPassportReader/ChipAuthenticationHandler.swift
+++ b/Sources/NFCPassportReader/ChipAuthenticationHandler.swift
@@ -44,7 +44,10 @@ class ChipAuthenticationHandler {
         }
         
         if chipAuthPublicKeyInfos.count > 0 {
+            Logger.chipAuth.info( "Chip Authentication supported: \(self.chipAuthPublicKeyInfos.count) public keys" )
             isChipAuthenticationSupported = true
+        } else {
+            Logger.chipAuth.info( "Chip Authentication not supported: \(self.chipAuthPublicKeyInfos.count) public keys" )
         }
     }
 

--- a/Sources/NFCPassportReader/DataGroups/CardAccess.swift
+++ b/Sources/NFCPassportReader/DataGroups/CardAccess.swift
@@ -17,10 +17,14 @@ public class CardAccess {
     private var asn1 : ASN1Item!
     public private(set) var securityInfos : [SecurityInfo] = [SecurityInfo]()
     
-    var paceInfo : PACEInfo? {
-        get {
-            return (securityInfos.filter { ($0 as? PACEInfo) != nil }).first as? PACEInfo
+    var paceInfo: PACEInfo? {
+        for securityInfo in securityInfos {
+            if let paceInfo = securityInfo as? PACEInfo,
+               (try? paceInfo.getMappingType()) == .GM {
+                return paceInfo
+            }
         }
+        return nil
     }
     
     required init( _ data : [UInt8] ) throws {

--- a/Sources/NFCPassportReader/Models/AuthenticationMethod.swift
+++ b/Sources/NFCPassportReader/Models/AuthenticationMethod.swift
@@ -1,0 +1,18 @@
+//
+//  AuthenticationMethod.swift
+//  NFCPassportReader
+//
+//  Created by Prem Eide on 11/11/2024.
+//
+
+public enum AuthenticationMethod: CustomStringConvertible {
+    case BAC
+    case PACE
+
+    public var description: String {
+        switch self {
+        case .BAC: return "BAC"
+        case .PACE: return "PACE"
+        }
+    }
+}

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -263,6 +263,7 @@ extension PassportReader {
             Logger.passportReader.error( "\(self.authenticationMethod) authentication failed - falling back to the other method" )
             authenticationMethod == .PACE ? try await doBACAuthentication(tagReader: tagReader) : try await doPACE(tagReader: tagReader)
         }
+        _ = try await tagReader.selectPassportApplication()
 
         // Now to read the datagroups
         try await readDataGroups(tagReader: tagReader)

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -289,8 +289,15 @@ extension PassportReader {
 
         Logger.passportReader.info( "Performing Active Authentication" )
 
-        let challenge = aaChallenge ?? generateRandomUInt8Array(8)
-        Logger.passportReader.debug( "Generated Active Authentication challange - \(binToHexRep(challenge))")
+        let challenge: [UInt8]
+        if let existingChallenge = aaChallenge {
+            challenge = existingChallenge
+            Logger.passportReader.debug("Using existing Active Authentication challenge - \(binToHexRep(challenge))")
+        } else {
+            challenge = generateRandomUInt8Array(8)
+            Logger.passportReader.debug("Generated new Active Authentication challenge - \(binToHexRep(challenge))")
+        }
+
         let response = try await tagReader.doInternalAuthentication(challenge: challenge, useExtendedMode: useExtendedMode)
         self.passport.verifyActiveAuthentication( challenge:challenge, signature:response.data )
     }

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -52,14 +52,12 @@ public class PassportReader : NSObject {
     private var readAllDatagroups = false
     private var skipSecureElements = true
     private var skipCA = false
-    private var skipPACE = false
-    
+    private var authenticationMethod: AuthenticationMethod = .PACE
+
     // Extended mode is used for reading eMRTD's that support extended length APDUs
     private var useExtendedMode = false
 
-    private var bacHandler : BACHandler?
     private var caHandler : ChipAuthenticationHandler?
-    private var paceHandler : PACEHandler?
     private var mrzKey : String = ""
     private var aaChallenge: [UInt8]?
     private var dataAmountToReadOverride : Int? = nil
@@ -91,13 +89,13 @@ public class PassportReader : NSObject {
         dataAmountToReadOverride = amount
     }
     
-    public func readPassport( mrzKey : String, tags : [DataGroupId] = [], aaChallenge: [UInt8]? = nil, skipSecureElements : Bool = true, skipCA : Bool = false, skipPACE : Bool = false, useExtendedMode : Bool = false, customDisplayMessage : ((NFCViewDisplayMessage) -> String?)? = nil) async throws -> NFCPassportModel {
+    public func readPassport( mrzKey : String, tags : [DataGroupId] = [], aaChallenge: [UInt8]? = nil, skipSecureElements : Bool = true, skipCA : Bool = false, authenticationMethod: AuthenticationMethod = .PACE, useExtendedMode : Bool = false, customDisplayMessage : ((NFCViewDisplayMessage) -> String?)? = nil) async throws -> NFCPassportModel {
         
         self.passport = NFCPassportModel()
         self.mrzKey = mrzKey
         self.aaChallenge = aaChallenge
         self.skipCA = skipCA
-        self.skipPACE = skipPACE
+        self.authenticationMethod = authenticationMethod
         self.useExtendedMode = useExtendedMode
         
         self.dataGroupsToRead.removeAll()
@@ -105,10 +103,8 @@ public class PassportReader : NSObject {
         self.nfcViewDisplayMessageHandler = customDisplayMessage
         self.skipSecureElements = skipSecureElements
         self.currentlyReadingDataGroup = nil
-        self.bacHandler = nil
         self.caHandler = nil
-        self.paceHandler = nil
-        
+
         // If no tags specified, read all
         if self.dataGroupsToRead.count == 0 {
             // Start off with .COM, will always read (and .SOD but we'll add that after), and then add the others from the COM
@@ -260,47 +256,14 @@ extension PassportReader {
     func startReading(tagReader : TagReader) async throws -> NFCPassportModel {
         trackingDelegate?.nfcTagDetected()
 
-        if !skipPACE {
-            do {
-                trackingDelegate?.paceStarted()
-
-                let data = try await tagReader.readCardAccess()
-                Logger.passportReader.debug( "Read CardAccess - data \(binToHexRep(data))" )
-                let cardAccess = try CardAccess(data)
-                passport.cardAccess = cardAccess
-
-                trackingDelegate?.readCardAccess(cardAccess: cardAccess)
-
-                Logger.passportReader.info( "Starting Password Authenticated Connection Establishment (PACE)" )
-                 
-                let paceHandler = try PACEHandler( cardAccess: cardAccess, tagReader: tagReader )
-                try await paceHandler.doPACE(mrzKey: mrzKey )
-                passport.PACEStatus = .success
-                Logger.passportReader.debug( "PACE Succeeded" )
-
-                trackingDelegate?.paceSucceeded()
-            } catch {
-                trackingDelegate?.paceFailed()
-
-                passport.PACEStatus = .failed
-                Logger.passportReader.error( "PACE Failed - falling back to BAC" )
-            }
-            
-            _ = try await tagReader.selectPassportApplication()
+        // Try the configured primary authentication method, falling back to the other if it fails
+        do {
+            authenticationMethod == .PACE ? try await doPACE(tagReader: tagReader) : try await doBACAuthentication(tagReader: tagReader)
+        } catch {
+            Logger.passportReader.error( "\(self.authenticationMethod) authentication failed - falling back to the other method" )
+            authenticationMethod == .PACE ? try await doBACAuthentication(tagReader: tagReader) : try await doPACE(tagReader: tagReader)
         }
-        
-        // If either PACE isn't supported, we failed whilst doing PACE or we didn't even attempt it, then fall back to BAC
-        if passport.PACEStatus != .success {
-            do {
-                trackingDelegate?.bacStarted()
-                try await doBACAuthentication(tagReader : tagReader)
-                trackingDelegate?.bacSucceeded()
-            } catch {
-                trackingDelegate?.bacFailed()
-                throw error
-            }
-        }
-        
+
         // Now to read the datagroups
         try await readDataGroups(tagReader: tagReader)
 
@@ -332,18 +295,52 @@ extension PassportReader {
     }
     
 
+    func doPACE(tagReader : TagReader) async throws {
+        trackingDelegate?.paceStarted()
+        do {
+            let data = try await tagReader.readCardAccess()
+            Logger.passportReader.debug( "Read CardAccess - data \(binToHexRep(data))" )
+            let cardAccess = try CardAccess(data)
+            passport.cardAccess = cardAccess
+
+            trackingDelegate?.readCardAccess(cardAccess: cardAccess)
+
+            Logger.passportReader.info( "Starting Password Authenticated Connection Establishment (PACE)" )
+
+            let paceHandler = try PACEHandler( cardAccess: cardAccess, tagReader: tagReader )
+            try await paceHandler.doPACE(mrzKey: mrzKey )
+            passport.PACEStatus = .success
+            Logger.passportReader.debug( "PACE Succeeded" )
+
+            trackingDelegate?.paceSucceeded()
+        } catch {
+            passport.PACEStatus = .failed
+            trackingDelegate?.paceFailed()
+            Logger.passportReader.error( "PACE failed" )
+            throw error
+        }
+    }
+
+
     func doBACAuthentication(tagReader : TagReader) async throws {
         self.currentlyReadingDataGroup = nil
 
+        trackingDelegate?.bacStarted()
         Logger.passportReader.info( "Starting Basic Access Control (BAC)" )
-        
+
         self.passport.BACStatus = .failed
 
-        self.bacHandler = BACHandler( tagReader: tagReader )
-        try await bacHandler?.performBACAndGetSessionKeys( mrzKey: mrzKey )
-        Logger.passportReader.info( "Basic Access Control (BAC) - SUCCESS!" )
+        do {
+            let bacHandler = BACHandler( tagReader: tagReader )
+            try await bacHandler.performBACAndGetSessionKeys( mrzKey: mrzKey )
+            Logger.passportReader.info( "Basic Access Control (BAC) - SUCCESS!" )
 
-        self.passport.BACStatus = .success
+            self.passport.BACStatus = .success
+            trackingDelegate?.bacSucceeded()
+        } catch {
+            trackingDelegate?.bacFailed()
+            throw error
+        }
     }
 
     func readDataGroups( tagReader: TagReader ) async throws {


### PR DESCRIPTION
### What
Adds an `authenticationMethod` parameter to `readPassport(...)` letting callers
choose whether **PACE** or **BAC** is attempted first, with automatic fallback
to the other if the primary fails. Replaces the previous `skipPACE: Bool` flag.

```swift
public enum AuthenticationMethod { case BAC, PACE }
// defaults to .PACE — existing behavior unchanged
```
### Why

Upstream hardcodes PACE-first. Some document/reader combinations are more
reliable starting with BAC; this gives integrators that control instead of an
all-or-nothing skip.

Also included

- Select the PACEInfo whose mapping type is GM (was: first match) — makes
PACE selection deterministic and avoids picking an unsupported mapping.
- Run selectPassportApplication() once after auth completes (works for either
path now that PACE/BAC are symmetric).
- Clearer logging for Active Authentication (supplied vs generated challenge)
and Chip Authentication support detection.

Notes

- skipPACE is removed; the SPM example app is updated accordingly.