### PR TITLE
Fix inverted boolean logic in TagReader.send() success/error check

### DIFF
--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -285,7 +285,7 @@ public class TagReader {
             
         }
         
-        if rep.sw1 != 0x90 && rep.sw2 != 0x00 {
+        if rep.sw1 != 0x90 || rep.sw2 != 0x00 {
             Logger.tagReader.error( "Error reading tag: sw1 - 0x\(binToHexRep(sw1)), sw2 - 0x\(binToHexRep(sw2))" )
             let tagError: NFCPassportReaderError
             if (rep.sw1 == 0x63 && rep.sw2 == 0x00) {


### PR DESCRIPTION
## Problem

`TagReader.send()` checks for a non-success status word like this:

```swift
if rep.sw1 != 0x90 && rep.sw2 != 0x00 {
    // treat as error
}
```

Per ISO 7816, success is exactly `sw1 == 0x90 AND sw2 == 0x00`. The
correct negation of that (i.e. "this is NOT success") is:

```swift
sw1 != 0x90 OR sw2 != 0x00
```

The current code uses `&&` instead of `||`. By De Morgan's law, this
means the error branch is only entered when **both** bytes differ from
the success value. Any status word where `sw2` happens to be exactly
`0x00` — which is common in the ISO 7816 table for generic/class-level
errors (`0x62/00`, `0x65/00`, `0x67/00` "Wrong length", `0x68/00`,
`0x69/00`, `0x6A/00`, `0x6D/00` "Instruction code not supported",
`0x6E/00` "Class not supported", `0x6F/00` "No precise diagnosis") —
is silently treated as success and returned as if it were valid data.

This also makes the `InvalidMRZKey` check unreachable in practice for
some paths, since it requires `sw2 == 0x00` to enter the outer `if` in
the first place, while the buggy condition requires `sw2 != 0x00` to
enter it — these two can never both hold.

## This is a regression from 1.1.9

The pre-async-rewrite version (1.1.9) checked success directly instead
of negating it, which avoided the mistake entirely:

```swift
if rep.sw1 == 0x90 && rep.sw2 == 0x00 {
    completed( rep, nil )
} else {
    // ... error handling, unconditionally reached whenever it's not
    // the case that both bytes equal the success value
}
```

During the async/await rewrite this was collapsed into a single
"is this an error" condition, and the negation was done incorrectly
(`&&` instead of `||`). Older issues predating the rewrite show these
exact `sw2 == 0x00` status words being correctly caught:
- #116 — `sw1 - 0x6D, sw2 - 0x00`
- #124 — `sw1 - 0x6F, sw2 - 0x00`

## Fix

```swift
if rep.sw1 != 0x90 || rep.sw2 != 0x00 {
```

One-line change, restores the pre-2.0 behavior. Pure bug fix, no
behavioral downside.